### PR TITLE
Use `QuadratureIterator` in examples

### DIFF
--- a/examples/LV.jl
+++ b/examples/LV.jl
@@ -57,7 +57,7 @@ function (postproc::StandardMechanicalIOPostProcessor2)(t, problem, solver_cache
             sdata_cell = Ferrite.Vec{3}((0.0, 0.0, 0.0))
             helixangle_cell = 0.0
             helixangleref_cell = 0.0
-            
+
             nqp = getnquadpoints(cv)
             for qp in QuadratureIterator(cv)
                 dΩ = getdetJdV(cv, qp)

--- a/examples/LV.jl
+++ b/examples/LV.jl
@@ -57,14 +57,13 @@ function (postproc::StandardMechanicalIOPostProcessor2)(t, problem, solver_cache
             sdata_cell = Ferrite.Vec{3}((0.0, 0.0, 0.0))
             helixangle_cell = 0.0
             helixangleref_cell = 0.0
-
+            
             nqp = getnquadpoints(cv)
-            for qpᵢ in 1:nqp
-                qp = QuadraturePoint(qpᵢ, cv.qr.points[qpᵢ])
-                dΩ = getdetJdV(cv, qpᵢ)
+            for qp in QuadratureIterator(cv)
+                dΩ = getdetJdV(cv, qp)
 
                 # Compute deformation gradient F
-                ∇u = function_gradient(cv, qpᵢ, uₑ)
+                ∇u = function_gradient(cv, qp, uₑ)
                 F = one(∇u) + ∇u
 
                 C = tdot(F)
@@ -80,7 +79,7 @@ function (postproc::StandardMechanicalIOPostProcessor2)(t, problem, solver_cache
                 s₀_current /= norm(s₀_current)
 
                 coords = getcoordinates(cell)
-                x_global = spatial_coordinate(cv, qpᵢ, coords)
+                x_global = spatial_coordinate(cv, qp, coords)
 
                 # v_longitudinal = function_gradient(cv_cs, qp, coordinate_system.u_apicobasal[celldofs(cell)])
                 # v_radial = function_gradient(cv_cs, qp, coordinate_system.u_transmural[celldofs(cell)])

--- a/examples/ring.jl
+++ b/examples/ring.jl
@@ -65,12 +65,11 @@ function (postproc::StandardMechanicalIOPostProcessor)(t, problem, solver_cache)
             helixangleref_cell = 0.0
 
             nqp = getnquadpoints(cv)
-            for qpᵢ in 1:nqp
-                qp = QuadraturePoint(qpᵢ, cv.qr.points[qpᵢ])
-                dΩ = getdetJdV(cv, qpᵢ)
+            for qp in QuadratureIterator(cv)
+                dΩ = getdetJdV(cv, qp)
 
                 # Compute deformation gradient F
-                ∇u = function_gradient(cv, qpᵢ, uₑ)
+                ∇u = function_gradient(cv, qp, uₑ)
                 F = one(∇u) + ∇u
 
                 C = tdot(F)
@@ -86,7 +85,7 @@ function (postproc::StandardMechanicalIOPostProcessor)(t, problem, solver_cache)
                 s₀_current /= norm(s₀_current)
 
                 coords = getcoordinates(cell)
-                x_global = spatial_coordinate(cv, qpᵢ, coords)
+                x_global = spatial_coordinate(cv, qp, coords)
 
                 # v_longitudinal = function_gradient(cv_cs, qp, coordinate_system.u_apicobasal[celldofs(cell)])
                 # v_radial = function_gradient(cv_cs, qp, coordinate_system.u_transmural[celldofs(cell)])

--- a/src/io.jl
+++ b/src/io.jl
@@ -124,7 +124,7 @@ function store_green_lagrange!(io::ParaViewWriter, dh, u::AbstractVector, a_coef
         field_dofs  = dof_range(sdh, field_idx)
         uₑ = @view u[global_dofs] # element dofs
         for qp in QuadratureIterator(cv)
-            ∇u = function_gradient(cv, qpᵢ, uₑ)
+            ∇u = function_gradient(cv, qp, uₑ)
 
             F = one(∇u) + ∇u
             C = tdot(F)

--- a/src/modeling/coupler/fsi.jl
+++ b/src/modeling/coupler/fsi.jl
@@ -78,7 +78,7 @@ function assemble_interface_coupling_contribution!(C, r, dh, u, setname, method:
             ∂V∂F = Tensors.gradient(u -> volume_integral(x, d, u, N, method), F)
             for j ∈ 1:getnbasefunctions(fv)
                 δuⱼ = shape_value(fv, qp, j)
-                ∇δuj = shape_gradient(cv, qpᵢ, j)
+                ∇δuj = shape_gradient(cv, qp, j)
                 C[1, ddofs[j]] += (∂V∂u ⋅ δuⱼ + ∂V∂F ⊡ ∇δuj) * dΓ
             end
         end

--- a/src/modeling/microstructure.jl
+++ b/src/modeling/microstructure.jl
@@ -94,9 +94,9 @@ function create_simple_microstructure_model(coordinate_system, ip::VectorInterpo
             transversal_angle = (1-transmural) * endo_transversal_angle + (transmural) * epi_transversal_angle
 
             f₀, s₀, n₀ = streeter_type_fsn(transmural_direction, circumferential_direction, apicobasal_direction, helix_angle, transversal_angle, sheetlet_pseudo_angle, make_orthogonal)
-            elementwise_data_f[cellindex, qp] = f₀
-            elementwise_data_s[cellindex, qp] = s₀
-            elementwise_data_n[cellindex, qp] = n₀
+            elementwise_data_f[cellindex, qp.i] = f₀
+            elementwise_data_s[cellindex, qp.i] = s₀
+            elementwise_data_n[cellindex, qp.i] = n₀
         end
     end
 

--- a/src/quadrature_iterator.jl
+++ b/src/quadrature_iterator.jl
@@ -35,6 +35,7 @@ Ferrite.shape_value(cv::CellValues, qp::QuadraturePoint, base_fun_idx::Int) = Fe
 Ferrite.shape_gradient(cv::CellValues, qp::QuadraturePoint, base_fun_idx::Int) = Ferrite.shape_gradient(cv, qp.i, base_fun_idx)
 Ferrite.function_value(cv::CellValues, qp::QuadraturePoint, ue) = Ferrite.function_value(cv, qp.i, ue)
 Ferrite.function_gradient(cv::CellValues, qp::QuadraturePoint, ue) = Ferrite.function_gradient(cv, qp.i, ue)
+Ferrite.spatial_coordinate(fe_v::Ferrite.AbstractValues, qp::QuadraturePoint, x::AbstractVector{<:Vec}) = spatial_coordinate(fe_v, qp.i, x)
 
 Ferrite.getdetJdV(fv::FaceValues, qp::QuadraturePoint) = Ferrite.getdetJdV(fv, qp.i)
 Ferrite.shape_value(fv::FaceValues, qp::QuadraturePoint, base_fun_idx::Int) = Ferrite.shape_value(fv, qp.i, base_fun_idx)


### PR DESCRIPTION
Uses `QuadratureIterator` in examples, changes some `qpᵢ` to `qp`,  uses `qp.i` for indexing, and dispatches `spatial_coordinate`.