### PR TITLE
Assembly interface overhaul

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -63,7 +63,10 @@ bibtex_plugin = CitationBibliography(
             "api-reference/solver.md",
             "api-reference/utility.md",
         ],
-        "devdocs/index.md",
+        "Developer Documentation" => [
+            "Overview" => "devdocs/index.md",
+            "devdocs/element_interface.md",
+        ],
         "references.md",
         ],
     plugins = [

--- a/docs/src/api-reference/discretization.md
+++ b/docs/src/api-reference/discretization.md
@@ -9,26 +9,4 @@ DocTestSetup = :(using Thunderbolt)
 ```@docs
 FiniteElementDiscretization
 Thunderbolt.semidiscretize
-Thunderbolt.assemble_element!
-Thunderbolt.assemble_face!
-Thunderbolt.assemble_interface_coupling_contribution!
-```
-## Common
-
-```@docs
-Thunderbolt.BilinearMassIntegrator
-Thunderbolt.BilinearMassElementCache
-Thunderbolt.BilinearDiffusionIntegrator
-Thunderbolt.BilinearDiffusionElementCache
-Thunderbolt.AnalyticalCoefficientElementCache
-```
-
-
-## Solid Mechanics
-
-### Elements
-
-```@docs
-Thunderbolt.StructuralElementCache
-Thunderbolt.SimpleFacetCache
 ```

--- a/docs/src/api-reference/models.md
+++ b/docs/src/api-reference/models.md
@@ -96,9 +96,10 @@ HartmannNeffCompressionPenalty3
 ## Electrophysiology
 
 ```@docs
+Thunderbolt.TransientHeatModel
 MonodomainModel
-ParabolicParabolicBidomainModel
-ParabolicEllipticBidomainModel
+Thunderbolt.ParabolicParabolicBidomainModel
+Thunderbolt.ParabolicEllipticBidomainModel
 ReactionDiffusionSplit
 ```
 

--- a/docs/src/api-reference/problems.md
+++ b/docs/src/api-reference/problems.md
@@ -11,7 +11,6 @@ Thunderbolt.PartitionedProblem
 Thunderbolt.ODEProblem
 Thunderbolt.AbstractPointwiseProblem
 Thunderbolt.PointwiseODEProblem
-Thunderbolt.TransientHeatProblem
 Thunderbolt.QuasiStaticNonlinearProblem
 Thunderbolt.QuasiStaticODEProblem
 Thunderbolt.QuasiStaticDAEProblem

--- a/docs/src/devdocs/element_interface.md
+++ b/docs/src/devdocs/element_interface.md
@@ -1,0 +1,50 @@
+```@meta
+DocTestSetup = :(using Thunderbolt)
+```
+
+# Element Interface
+
+## Entry Points
+
+```@docs
+Thunderbolt.AbstractVolumetricElementCache
+Thunderbolt.AbstractSurfaceElementCache
+Thunderbolt.AbstractInterfaceElementCache
+Thunderbolt.assemble_element!
+Thunderbolt.assemble_face!
+Thunderbolt.assemble_interface!
+```
+
+
+## Common
+
+```@docs
+Thunderbolt.AnalyticalCoefficientElementCache
+Thunderbolt.SimpleFacetCache
+```
+
+## Composite
+
+```@docs
+Thunderbolt.CompositeVolumetricElementCache
+Thunderbolt.CompositeSurfaceElementCache
+Thunderbolt.CompositeInterfaceElementCache
+```
+
+## Bilinear
+
+```@docs
+Thunderbolt.BilinearMassIntegrator
+Thunderbolt.BilinearMassElementCache
+Thunderbolt.BilinearDiffusionIntegrator
+Thunderbolt.BilinearDiffusionElementCache
+```
+
+
+## Solid Mechanics
+
+### Elements
+
+```@docs
+Thunderbolt.StructuralElementCache
+```

--- a/examples/lv-with-mtk-circuit.jl
+++ b/examples/lv-with-mtk-circuit.jl
@@ -187,7 +187,7 @@ u0 = [
     PULVEN.L.q => 0.0
 ]
 
-prob = ODEProblem(circ_sys_init, u0, (0.0, 20.0e3))
+prob = OrdinaryDiffEq.ODEProblem(circ_sys_init, u0, (0.0, 20.0e3))
 ##
 @time circ_sol_init = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-12, saveat=18e3:0.01e3:20e3)
 
@@ -321,7 +321,7 @@ timestepper = LieTrotterGodunov((
             )
         )
     ),
-    ForwardEulerSolver(ceil(Int, dt₀/0.001)), # Force time step to about 0.001
+    ForwardEulerSolver(rate=ceil(Int, dt₀/0.001)), # Force time step to about 0.001
 ))
 
 u₀ = zeros(solution_size(coupledform))

--- a/examples/ring.jl
+++ b/examples/ring.jl
@@ -65,7 +65,12 @@ quasistaticform = semidiscretize(
 )
 
 problem = QuasiStaticProblem(quasistaticform, tspan)
-timestepper = LoadDrivenSolver(NewtonRaphsonSolver(;max_iter=100))
+timestepper = LoadDrivenSolver(
+    NewtonRaphsonSolver(
+        max_iter=10,
+        inner_solver=LinearSolve.UMFPACKFactorization(),
+    )
+)
 
 integrator = OS.init(problem, timestepper, dt=dt₀, verbose=true)
 

--- a/src/Thunderbolt.jl
+++ b/src/Thunderbolt.jl
@@ -2,6 +2,8 @@ module Thunderbolt
 
 using TimerOutputs
 
+import Unrolled: @unroll
+
 using Reexport, UnPack
 import LinearAlgebra: mul!
 using SparseMatricesCSR, Polyester, LinearAlgebra

--- a/src/discretization/operator.jl
+++ b/src/discretization/operator.jl
@@ -236,9 +236,10 @@ function update_linearization!(op::AssembledNonlinearOperator, u::AbstractVector
         @timeit_debug "assemble element" assemble_element!(Jₑ, uₑ, cell, element_cache, time)
         # TODO maybe it makes sense to merge this into the element routine in a modular fasion?
         # TODO benchmark against putting this into the FacetIterator
-        @timeit_debug "assemble faces" for local_face_index ∈ 1:nfacets(cell)
-            assemble_face!(Jₑ, uₑ, cell, local_face_index, face_cache, time)
-        end
+        # @timeit_debug "assemble faces" for local_face_index ∈ 1:nfacets(cell)
+        #     assemble_face!(Jₑ, uₑ, cell, local_face_index, face_cache, time)
+        # end
+        @timeit_debug "assemble faces" assemble_element!(Jₑ, uₑ, cell, local_face_index, face_cache, time)
         @timeit_debug "assemble tying"  assemble_tying!(Jₑ, uₑ, uₜ, cell, tying_cache, time)
         assemble!(assembler, celldofs(cell), Jₑ)
     end
@@ -264,9 +265,10 @@ function update_linearization!(op::AssembledNonlinearOperator, u::AbstractVector
         @timeit_debug "assemble element" assemble_element!(Jₑ, rₑ, uₑ, cell, element_cache, time)
         # TODO maybe it makes sense to merge this into the element routine in a modular fasion?
         # TODO benchmark against putting this into the FacetIterator
-        @timeit_debug "assemble faces" for local_face_index ∈ 1:nfacets(cell)
-            assemble_face!(Jₑ, rₑ, uₑ, cell, local_face_index, face_cache, time)
-        end
+        # @timeit_debug "assemble faces" for local_face_index ∈ 1:nfacets(cell)
+        #     assemble_face!(Jₑ, rₑ, uₑ, cell, local_face_index, face_cache, time)
+        # end
+        @timeit_debug "assemble faces" assemble_element!(Jₑ, rₑ, uₑ, cell, face_cache, time)
         @timeit_debug "assemble tying"  assemble_tying!(Jₑ, rₑ, uₑ, uₜ, cell, tying_cache, time)
         assemble!(assembler, dofs, Jₑ, rₑ)
     end
@@ -469,38 +471,6 @@ end
 Ferrite.add!(b::AbstractVector, op::AbstractLinearOperator) = b .+= op.b
 Base.eltype(op::AbstractLinearOperator) = eltype(op.b)
 Base.size(op::AbstractLinearOperator) = sisze(op.b)
-
-# TODO where to put these?
-struct AnalyticalCoefficientElementCache{F <: AnalyticalCoefficient, T, CV}
-    f::F
-    nonzero_intervals::Vector{SVector{2,T}}
-    cv::CV
-end
-duplicate_for_parallel(ec::AnalyticalCoefficientElementCache) = AnalyticalCoefficientElementCache(ec.f, ec.nonzero_intervals, ec.cv)
-function assemble_element!(bₑ, cell, element_cache::AnalyticalCoefficientElementCache, time)
-    _assemble_element!(bₑ, getcoordinates(cell), element_cache::AnalyticalCoefficientElementCache, time)
-end
-# We want this to be as fast as possible, so throw away everything unused
-@inline function _assemble_element!(bₑ, coords::AbstractVector{<:Vec{dim,T}}, element_cache::AnalyticalCoefficientElementCache, time) where {dim,T}
-    @unpack f, cv = element_cache
-    n_geom_basefuncs = Ferrite.getngeobasefunctions(cv)
-    @inbounds for (qp, w) in pairs(Ferrite.getweights(cv.qr))
-        # Compute dΩ
-        mapping = Ferrite.calculate_mapping(cv.geo_mapping, qp, coords)
-        dΩ = Ferrite.calculate_detJ(Ferrite.getjacobian(mapping)) * w
-        # Compute x
-        x = spatial_coordinate(cv, qp, coords)
-        # Evaluate f
-        fx = f.f(x,time)
-        # TODO replace with evaluate_coefficient
-        # Evaluate all basis functions
-        @inbounds for j ∈ 1:getnbasefunctions(cv)
-            δu = shape_value(cv, qp, j)
-            bₑ[j] += fx * δu * dΩ
-        end
-    end
-end
-
 
 function needs_update(op::Union{LinearOperator, PEALinearOperator}, t)
     return _needs_update(op, op.element_cache, t)

--- a/src/discretization/rsafdq-operator.jl
+++ b/src/discretization/rsafdq-operator.jl
@@ -43,7 +43,10 @@ getJ(op::AssembledRSAFDQ2022Operator, i::Block) = @view op.J[i]
 function update_linearization!(op::AssembledRSAFDQ2022Operator, u_::AbstractVector, time)
     @unpack J, element_cache, face_cache, tying_cache, dh  = op
 
-    u = PseudoBlockVector(u_, blocksizes(J)[1])
+    bs = blocksizes(J)
+    s1 = bs[1,1][1]
+    s2 = bs[2,2][1]
+    u  = BlockedVector(u_, [s1, s2])
     ud = @view u[Block(1)]
     up = @view u[Block(2)]
 
@@ -92,14 +95,17 @@ function update_linearization!(op::AssembledRSAFDQ2022Operator, u_::AbstractVect
     #finish_assemble(assembler)
 end
 
-function update_linearization!(op::AssembledRSAFDQ2022Operator, u_::AbstractVector, residual_::AbstractVector, time)
+function update_linearization!(op::AssembledRSAFDQ2022Operator, residual_::AbstractVector, u_::AbstractVector, time)
     @unpack J, element_cache, face_cache, tying_cache, dh  = op
 
-    u = PseudoBlockVector(u_, blocksizes(J)[1])
+    bs = blocksizes(J)
+    s1 = bs[1,1][1]
+    s2 = bs[2,2][1]
+    u  = BlockedVector(u_, [s1, s2])
     ud = @view u[Block(1)]
     up = @view u[Block(2)]
 
-    residual = PseudoBlockVector(residual_, blocksizes(J)[1])
+    residual  = BlockedVector(residual_, [s1, s2])
     residuald = @view residual[Block(1)]
     residualp = @view residual[Block(2)]
 

--- a/src/modeling/common.jl
+++ b/src/modeling/common.jl
@@ -19,8 +19,11 @@ end
 abstract type AbstractSourceTerm end
 
 include("core/coefficients.jl")
+include("core/analytical_coefficient.jl")
 
-include("core/boundary_conditions.jl")
+include("core/element_interface.jl")
+include("core/composite_elements.jl")
+include("core/weak_boundary_conditions.jl")
 
 abstract type AbstractBilinearIntegrator end
 include("core/mass.jl")

--- a/src/modeling/core/analytical_coefficient.jl
+++ b/src/modeling/core/analytical_coefficient.jl
@@ -1,0 +1,37 @@
+"""
+    AnalyticalCoefficientElementCache(f(x,t)->..., nonzero_in_time_intervals, cellvalues)
+
+Analytical coefficient described by a function in space and time.
+Can be sparse in time.
+"""
+struct AnalyticalCoefficientElementCache{F <: AnalyticalCoefficient, T, CV}
+    f::F
+    nonzero_intervals::Vector{SVector{2,T}}
+    cv::CV
+end
+duplicate_for_parallel(ec::AnalyticalCoefficientElementCache) = AnalyticalCoefficientElementCache(ec.f, ec.nonzero_intervals, ec.cv)
+
+@inline function assemble_element!(bₑ::AbstractVector, cell::CellCache, element_cache::AnalyticalCoefficientElementCache, time)
+    _assemble_element!(bₑ, getcoordinates(cell), element_cache::AnalyticalCoefficientElementCache, time)
+end
+
+# We want this to be as fast as possible, so throw away everything unused
+@inline function _assemble_element!(bₑ::AbstractVector, coords::AbstractVector{<:Vec{dim,T}}, element_cache::AnalyticalCoefficientElementCache, time) where {dim,T}
+    @unpack f, cv = element_cache
+    n_geom_basefuncs = Ferrite.getngeobasefunctions(cv)
+    @inbounds for (qp, w) in pairs(Ferrite.getweights(cv.qr))
+        # Compute dΩ
+        mapping = Ferrite.calculate_mapping(cv.geo_mapping, qp, coords)
+        dΩ = Ferrite.calculate_detJ(Ferrite.getjacobian(mapping)) * w
+        # Compute x
+        x = spatial_coordinate(cv, qp, coords)
+        # Evaluate f
+        fx = f.f(x,time)
+        # TODO replace with evaluate_coefficient
+        # Evaluate all basis functions
+        @inbounds for j ∈ 1:getnbasefunctions(cv)
+            δu = shape_value(cv, qp, j)
+            bₑ[j] += fx * δu * dΩ
+        end
+    end
+end

--- a/src/modeling/core/coefficients.jl
+++ b/src/modeling/core/coefficients.jl
@@ -29,7 +29,7 @@ function evaluate_coefficient(coeff::FieldCoefficient{<:Any,<:Any,<:Any,<:Scalar
     return val
 end
 
-function evaluate_coefficient(coeff::FieldCoefficient{<:Any,<:Any,<:Any,<:VectorizedInterpolationCollection{vdim}}, cell_cache, qp::QuadraturePoint{<:Any, T}, t) where {vdim,T}
+function evaluate_coefficient(coeff::F, cell_cache, qp::QuadraturePoint{<:Any, T}, t) where {vdim, T, F <: FieldCoefficient{<:Any,<:Any,<:Any,<:VectorizedInterpolationCollection{vdim}}}
     @unpack elementwise_data, ip_collection = coeff
     ip = getinterpolation(ip_collection, getcells(cell_cache.grid, cellid(cell_cache)))
     n_base_funcs = Ferrite.getnbasefunctions(ip.ip)
@@ -139,7 +139,7 @@ struct AnalyticalCoefficient{F<:Function, CSYS<:CoordinateSystemCoefficient}
     coordinate_system_coefficient::CSYS
 end
 
-function evaluate_coefficient(coeff::AnalyticalCoefficient{F}, cell_cache, qp::QuadraturePoint{<:Any,T}, t) where {F, T}
+function evaluate_coefficient(coeff::F, cell_cache, qp::QuadraturePoint{<:Any,T}, t) where {F <: AnalyticalCoefficient, T}
     x = evaluate_coefficient(coeff.coordinate_system_coefficient, cell_cache, qp, t)
     return coeff.f(x, t)
 end

--- a/src/modeling/core/composite_elements.jl
+++ b/src/modeling/core/composite_elements.jl
@@ -1,0 +1,138 @@
+function setup_boundary_cache(boundary_models::Tuple, qr::FacetQuadratureRule, ip, ip_geo)
+    length(boundary_models) == 0 && return EmptySurfaceCache()
+    # TODO decompose first into cell groups by subdomains, then into composites
+    return CompositeVolumetricElementCache(
+        ntuple(i->setup_boundary_cache(boundary_models[i], qr, ip, ip_geo), length(boundary_models))
+    )
+end
+
+"""
+This cache allows to combine multiple elements over the same volume.
+If surface caches are passed they are handled properly. This requred dispatching
+    is_facet_in_cache(facet::FacetIndex, geometry_cache, my_cache::MyCacheType)
+"""
+struct CompositeVolumetricElementCache{CacheTupleType <: Tuple} <: AbstractVolumetricElementCache
+    inner_caches::CacheTupleType
+end
+# Main entry point for bilinear operators
+assemble_element!(Kₑ::AbstractMatrix, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, cell, element_cache.inner_caches, time)
+@unroll function assemble_element!(Kₑ::AbstractMatrix, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_element!(Kₑ, cell, inner_cache, time)
+    end
+end
+# Update element matrix in nonlinear operators
+assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, u, cell, element_cache.inner_caches, time)
+@unroll function assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_element!(Kₑ, cell, inner_cache, time)
+    end
+end
+# Update element matrix and residual in nonlinear operators
+assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, residualₑ, u, cell, element_cache.inner_caches, time)
+@unroll function assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_element!(Kₑ, residualₑ, u, cell, inner_cache, time)
+    end
+end
+# Update residual in nonlinear operators
+assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, cell, element_cache.inner_caches, time)
+@unroll function assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_element!(residualₑ, u, cell, inner_cache, time)
+    end
+end
+
+# If we compose a face cache into an element cache, then we loop over the faces of the elements and try to assemble
+function assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, facet_cache::AbstractSurfaceElementCache, time)
+    for local_facet_index ∈ 1:nfacets(cell)
+        if is_facet_in_cache(FacetIndex(cellid(cell), local_facet_index), cell, facet_cache)
+            assemble_face!(Kₑ, u, cell, local_facet_index, facet_cache, time)
+        end
+    end
+end
+function assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, facet_cache::AbstractSurfaceElementCache, time)
+    for local_facet_index ∈ 1:nfacets(cell)
+        if is_facet_in_cache(FacetIndex(cellid(cell), local_facet_index), cell, facet_cache)
+            assemble_face!(Kₑ, residualₑ, u, cell, local_facet_index, facet_cache, time)
+        end
+    end
+end
+function assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, facet_cache::AbstractSurfaceElementCache, time)
+    for local_facet_index ∈ 1:nfacets(cell)
+        if is_facet_in_cache(FacetIndex(cellid(cell), local_facet_index), cell, facet_cache)
+            assemble_face!(residualₑ, u, cell, local_facet_index, facet_cache, time)
+        end
+    end
+end
+
+
+"""
+This cache allows to combine multiple elements over the same surface.
+"""
+struct CompositeSurfaceElementCache{CacheTupleType <: Tuple} <: AbstractSurfaceElementCache
+    inner_caches::CacheTupleType
+end
+# Main entry point for bilinear operators
+assemble_face!(Kₑ::AbstractMatrix, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, cell, surface_cache.inner_caches, local_facet_index, time)
+@unroll function assemble_face!(Kₑ::AbstractMatrix, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_face!(Kₑ, cell, local_facet_index, inner_cache, time)
+    end
+end
+# Update element matrix in nonlinear operators
+assemble_face!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, u, cell, local_facet_index, surface_cache.inner_caches, time)
+@unroll function assemble_face!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_face!(Kₑ, u, cell, local_facet_index, inner_cache, time)
+    end
+end
+# Update element matrix and residual in nonlinear operators
+assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, residualₑ, u, cell, local_facet_index, surface_cache.inner_caches, time)
+@unroll function assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_face!(Kₑ, residualₑ, u, cell, local_facet_index, inner_cache, time)
+    end
+end
+# Update residual in nonlinear operators
+assemble_face!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, cell, local_facet_index, surface_cache.inner_caches, time)
+@unroll function assemble_face!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_face!(residualₑ, u, cell, local_facet_index, inner_cache, time)
+    end
+end
+
+"""
+This cache allows to combine multiple elements over the same interface.
+"""
+struct CompositeInterfaceElementCache{CacheTupleType <: Tuple} <: AbstractInterfaceElementCache
+    inner_caches::CacheTupleType
+end
+# Main entry point for bilinear operators
+assemble_interface!(Kₑ::AbstractMatrix, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, interface, interface_cache.inner_caches, time)
+@unroll function assemble_interface!(Kₑ::AbstractMatrix, interface, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_interface!(Kₑ, interface, inner_cache, time)
+    end
+end
+# Update element matrix in nonlinear operators
+assemble_interface!(Kₑ::AbstractMatrix, u::AbstractVector, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, u, interface, interface_cache.inner_caches, time)
+@unroll function assemble_interface!(Kₑ::AbstractMatrix, u::AbstractVector, interface, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_interface!(Kₑ, u, interface, inner_cache, local_facet_index, time)
+    end
+end
+# Update element matrix and residual in nonlinear operators
+assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, residualₑ, u, interface, interface_cache.inner_caches, time)
+@unroll function assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, interface, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_interface!(Kₑ, residualₑ, u, interface, inner_cache, local_facet_index, time)
+    end
+end
+# Update residual in nonlinear operators
+assemble_interface!(residualₑ::AbstractVector, u::AbstractVector, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, interface, interface_cache.inner_caches, time)
+@unroll function assemble_interface!(residualₑ::AbstractVector, u::AbstractVector, interface, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+    @unroll for inner_cache ∈ inner_caches
+        assemble_interface!(residualₑ, u, interface, inner_cache, local_facet_index, time)
+    end
+end

--- a/src/modeling/core/composite_elements.jl
+++ b/src/modeling/core/composite_elements.jl
@@ -22,46 +22,46 @@ assemble_element!(Kₑ::AbstractMatrix, cell::CellCache, element_cache::Composit
     end
 end
 # Update element matrix in nonlinear operators
-assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, u, cell, element_cache.inner_caches, time)
-@unroll function assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
+assemble_element!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, uₑ, cell, element_cache.inner_caches, time)
+@unroll function assemble_element!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
     @unroll for inner_cache ∈ inner_caches
         assemble_element!(Kₑ, cell, inner_cache, time)
     end
 end
 # Update element matrix and residual in nonlinear operators
-assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, residualₑ, u, cell, element_cache.inner_caches, time)
-@unroll function assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
+assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, residualₑ, uₑ, cell, element_cache.inner_caches, time)
+@unroll function assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
     @unroll for inner_cache ∈ inner_caches
-        assemble_element!(Kₑ, residualₑ, u, cell, inner_cache, time)
+        assemble_element!(Kₑ, residualₑ, uₑ, cell, inner_cache, time)
     end
 end
 # Update residual in nonlinear operators
-assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, cell, element_cache.inner_caches, time)
-@unroll function assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
+assemble_element!(residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, element_cache::CompositeVolumetricElementCache, time) = assemble_element!(Kₑ, cell, element_cache.inner_caches, time)
+@unroll function assemble_element!(residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, time) where CacheTupleType <: Tuple
     @unroll for inner_cache ∈ inner_caches
-        assemble_element!(residualₑ, u, cell, inner_cache, time)
+        assemble_element!(residualₑ, uₑ, cell, inner_cache, time)
     end
 end
 
 # If we compose a face cache into an element cache, then we loop over the faces of the elements and try to assemble
-function assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, facet_cache::AbstractSurfaceElementCache, time)
+function assemble_element!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, facet_cache::AbstractSurfaceElementCache, time)
     for local_facet_index ∈ 1:nfacets(cell)
         if is_facet_in_cache(FacetIndex(cellid(cell), local_facet_index), cell, facet_cache)
-            assemble_face!(Kₑ, u, cell, local_facet_index, facet_cache, time)
+            assemble_face!(Kₑ, uₑ, cell, local_facet_index, facet_cache, time)
         end
     end
 end
-function assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, facet_cache::AbstractSurfaceElementCache, time)
+function assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, facet_cache::AbstractSurfaceElementCache, time)
     for local_facet_index ∈ 1:nfacets(cell)
         if is_facet_in_cache(FacetIndex(cellid(cell), local_facet_index), cell, facet_cache)
-            assemble_face!(Kₑ, residualₑ, u, cell, local_facet_index, facet_cache, time)
+            assemble_face!(Kₑ, residualₑ, uₑ, cell, local_facet_index, facet_cache, time)
         end
     end
 end
-function assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, facet_cache::AbstractSurfaceElementCache, time)
+function assemble_element!(residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, facet_cache::AbstractSurfaceElementCache, time)
     for local_facet_index ∈ 1:nfacets(cell)
         if is_facet_in_cache(FacetIndex(cellid(cell), local_facet_index), cell, facet_cache)
-            assemble_face!(residualₑ, u, cell, local_facet_index, facet_cache, time)
+            assemble_face!(residualₑ, uₑ, cell, local_facet_index, facet_cache, time)
         end
     end
 end
@@ -81,24 +81,24 @@ assemble_face!(Kₑ::AbstractMatrix, cell::CellCache, local_facet_index::Int, su
     end
 end
 # Update element matrix in nonlinear operators
-assemble_face!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, u, cell, local_facet_index, surface_cache.inner_caches, time)
-@unroll function assemble_face!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+assemble_face!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, uₑ, cell, local_facet_index, surface_cache.inner_caches, time)
+@unroll function assemble_face!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
     @unroll for inner_cache ∈ inner_caches
-        assemble_face!(Kₑ, u, cell, local_facet_index, inner_cache, time)
+        assemble_face!(Kₑ, uₑ, cell, local_facet_index, inner_cache, time)
     end
 end
 # Update element matrix and residual in nonlinear operators
-assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, residualₑ, u, cell, local_facet_index, surface_cache.inner_caches, time)
-@unroll function assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, residualₑ, uₑ, cell, local_facet_index, surface_cache.inner_caches, time)
+@unroll function assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
     @unroll for inner_cache ∈ inner_caches
-        assemble_face!(Kₑ, residualₑ, u, cell, local_facet_index, inner_cache, time)
+        assemble_face!(Kₑ, residualₑ, uₑ, cell, local_facet_index, inner_cache, time)
     end
 end
 # Update residual in nonlinear operators
-assemble_face!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, cell, local_facet_index, surface_cache.inner_caches, time)
-@unroll function assemble_face!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+assemble_face!(residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, local_facet_index::Int, surface_cache::CompositeSurfaceElementCache, time) = assemble_face!(Kₑ, cell, local_facet_index, surface_cache.inner_caches, time)
+@unroll function assemble_face!(residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
     @unroll for inner_cache ∈ inner_caches
-        assemble_face!(residualₑ, u, cell, local_facet_index, inner_cache, time)
+        assemble_face!(residualₑ, uₑ, cell, local_facet_index, inner_cache, time)
     end
 end
 
@@ -116,23 +116,23 @@ assemble_interface!(Kₑ::AbstractMatrix, interface, interface_cache::CompositeI
     end
 end
 # Update element matrix in nonlinear operators
-assemble_interface!(Kₑ::AbstractMatrix, u::AbstractVector, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, u, interface, interface_cache.inner_caches, time)
-@unroll function assemble_interface!(Kₑ::AbstractMatrix, u::AbstractVector, interface, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+assemble_interface!(Kₑ::AbstractMatrix, uₑ::AbstractVector, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, uₑ, interface, interface_cache.inner_caches, time)
+@unroll function assemble_interface!(Kₑ::AbstractMatrix, uₑ::AbstractVector, interface, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
     @unroll for inner_cache ∈ inner_caches
-        assemble_interface!(Kₑ, u, interface, inner_cache, local_facet_index, time)
+        assemble_interface!(Kₑ, uₑ, interface, inner_cache, local_facet_index, time)
     end
 end
 # Update element matrix and residual in nonlinear operators
-assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, residualₑ, u, interface, interface_cache.inner_caches, time)
-@unroll function assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, interface, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, residualₑ, uₑ, interface, interface_cache.inner_caches, time)
+@unroll function assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, interface, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
     @unroll for inner_cache ∈ inner_caches
-        assemble_interface!(Kₑ, residualₑ, u, interface, inner_cache, local_facet_index, time)
+        assemble_interface!(Kₑ, residualₑ, uₑ, interface, inner_cache, local_facet_index, time)
     end
 end
 # Update residual in nonlinear operators
-assemble_interface!(residualₑ::AbstractVector, u::AbstractVector, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, interface, interface_cache.inner_caches, time)
-@unroll function assemble_interface!(residualₑ::AbstractVector, u::AbstractVector, interface, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
+assemble_interface!(residualₑ::AbstractVector, uₑ::AbstractVector, interface, interface_cache::CompositeInterfaceElementCache, time) = assemble_interface!(Kₑ, interface, interface_cache.inner_caches, time)
+@unroll function assemble_interface!(residualₑ::AbstractVector, uₑ::AbstractVector, interface, inner_caches::CacheTupleType, local_facet_index::Int,  time) where CacheTupleType <: Tuple
     @unroll for inner_cache ∈ inner_caches
-        assemble_interface!(residualₑ, u, interface, inner_cache, local_facet_index, time)
+        assemble_interface!(residualₑ, uₑ, interface, inner_cache, local_facet_index, time)
     end
 end

--- a/src/modeling/core/diffusion.jl
+++ b/src/modeling/core/diffusion.jl
@@ -1,17 +1,16 @@
-# @doc raw"""
-#     BilinearDiffusionIntegrator{CoefficientType}
+@doc raw"""
+    BilinearDiffusionIntegrator{CoefficientType}
 
-# Assembles the matrix associated to the bilinearform ``a(u,v) = -\int \nabla v(x) \cdot D(x) \nabla u(x) dx`` for a given diffusion tensor ``D(x)`` and ``u,v`` from the same function space.
-# """
-"""
-    Represents the integrand of the bilinear form <ϕ,ψ> = -∫ D∇ϕ ⋅ ∇ψ dΩ .
+Represents the integrand of the bilinear form ``a(u,v) = -\int \nabla v(x) \cdot D(x) \nabla u(x) dx`` for a given diffusion tensor ``D(x)`` and ``u,v`` from the same function space.
 """
 struct BilinearDiffusionIntegrator{CoefficientType} <: AbstractBilinearIntegrator
     D::CoefficientType
-    # coordinate_system
 end
 
-struct BilinearDiffusionElementCache{IT <: BilinearDiffusionIntegrator, CV}
+"""
+The cache associated with [`BilinearDiffusionIntegrator`](@ref) to assemble element diffusion matrices.
+"""
+struct BilinearDiffusionElementCache{IT <: BilinearDiffusionIntegrator, CV} <: AbstractVolumetricElementCache
     integrator::IT
     cellvalues::CV
 end
@@ -37,6 +36,11 @@ end
 
 setup_element_cache(element_model::BilinearDiffusionIntegrator, qr, ip, ip_geo) = BilinearDiffusionElementCache(element_model, CellValues(qr, ip, ip_geo))
 
+@doc raw"""
+    TransientHeatModel(conductivity_coefficient, source_term, solution_variable_symbol)
+
+Model formulated as ``\partial_t u = \nabla \cdot \kappa(x) \nabla u``
+"""
 struct TransientHeatModel{ConductivityCoefficientType, SourceType <: AbstractSourceTerm}
     κ::ConductivityCoefficientType
     source::SourceType

--- a/src/modeling/core/element_interface.jl
+++ b/src/modeling/core/element_interface.jl
@@ -8,7 +8,7 @@ Interface:
 """
 abstract type AbstractVolumetricElementCache end
 
-"""
+@doc raw"""
     assemble_element!(Kₑ::AbstractMatrix, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
 Main entry point for bilinear operators
 
@@ -54,7 +54,7 @@ Interface:
 """
 abstract type AbstractSurfaceElementCache end
 
-"""
+@doc raw"""
     assemble_face!(Kₑ::AbstractMatrix, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Main entry point for bilinear operators
 
@@ -100,7 +100,7 @@ Interface:
 """
 abstract type AbstractInterfaceElementCache end
 
-"""
+@doc raw"""
     assemble_interface!(Kₑ::AbstractMatrix, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Main entry point for bilinear operators
 

--- a/src/modeling/core/element_interface.jl
+++ b/src/modeling/core/element_interface.jl
@@ -12,14 +12,19 @@ abstract type AbstractVolumetricElementCache end
     assemble_element!(Kₑ::AbstractMatrix, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
 Main entry point for bilinear operators
 
-    assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
+    assemble_element!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
 Update element matrix in nonlinear operators
 
-    assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
+    assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
 Update element matrix and residual in nonlinear operators
 
-    assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
+    assemble_element!(residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
 Update residual in nonlinear operators
+
+The notation is as follows.
+* $K_e$ the element stiffness matrix
+* $u_e$ the element unknowns
+* $residual_e$ the element residual
 """
 assemble_element!
 
@@ -31,11 +36,11 @@ struct EmptyVolumetricElementCache <: AbstractVolumetricElementCache end
 # Main entry point for bilinear operators
 assemble_element!(Kₑ::AbstractMatrix, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
 # Update element matrix in nonlinear operators
-assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
+assemble_element!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
 # Update element matrix and residual in nonlinear operators
-assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
+assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
 # Update residual in nonlinear operators
-assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
+assemble_element!(residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
 
 
 
@@ -53,14 +58,19 @@ abstract type AbstractSurfaceElementCache end
     assemble_face!(Kₑ::AbstractMatrix, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Main entry point for bilinear operators
 
-    assemble_face!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+    assemble_face!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Update face matrix in nonlinear operators
 
-    assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+    assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Update face matrix and residual in nonlinear operators
 
-    assemble_face!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+    assemble_face!(residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Update residual in nonlinear operators
+
+The notation is as follows.
+* $K_e$ the element stiffness matrix
+* $u_e$ the element unknowns
+* $residual_e$ the element residual
 """
 assemble_face!
 
@@ -70,14 +80,14 @@ assemble_face!
 """
 struct EmptySurfaceCache <: AbstractSurfaceElementCache end
 # Update element matrix in nonlinear operators
-assemble_face!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, local_face_index::Int, face_caches::EmptySurfaceCache, time)    = nothing
-assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, local_face_index::Int, face_caches::EmptySurfaceCache, time) = nothing
+assemble_face!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, local_face_index::Int, face_caches::EmptySurfaceCache, time)    = nothing
+assemble_element!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, local_face_index::Int, face_caches::EmptySurfaceCache, time) = nothing
 # Update element matrix and residual in nonlinear operators
-assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time)    = nothing
-assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time) = nothing
+assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time)    = nothing
+assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time) = nothing
 # Update residual in nonlinear operators
-assemble_face!(residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time)    = nothing
-assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time) = nothing
+assemble_face!(residualₑ::AbstractVector, uₑ::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time)    = nothing
+assemble_element!(residualₑ::AbstractVector, uₑ::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time) = nothing
 @inline is_facet_in_cache(::FacetIndex, cell, ::EmptySurfaceCache) = false
 
 """
@@ -94,14 +104,19 @@ abstract type AbstractInterfaceElementCache end
     assemble_interface!(Kₑ::AbstractMatrix, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Main entry point for bilinear operators
 
-    assemble_interface!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+    assemble_interface!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Update face matrix in nonlinear operators
 
-    assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+    assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Update face matrix and residual in nonlinear operators
 
-    assemble_interface!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+    assemble_interface!(residualₑ::AbstractVector, uₑ::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
 Update residual in nonlinear operators
+
+The notation is as follows.
+* $K_e$ the element pair stiffness matrix
+* $u_e$ the element pair unknowns
+* $residual_e$ the element pair residual
 """
 assemble_interface!
 
@@ -111,9 +126,9 @@ Utility to execute noop assembly.
 """
 struct EmptyInterfaceCache <: AbstractInterfaceElementCache end
 # Update element matrix in nonlinear operators
-assemble_interface!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, local_face_index::Int, face_caches::EmptyInterfaceCache, time)            = nothing
+assemble_interface!(Kₑ::AbstractMatrix, uₑ::AbstractVector, cell::CellCache, local_face_index::Int, face_caches::EmptyInterfaceCache, time)            = nothing
 # Update element matrix and residual in nonlinear operators
-assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptyInterfaceCache, time) = nothing
+assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, cell, local_face_index::Int, face_caches::EmptyInterfaceCache, time) = nothing
 # Update residual in nonlinear operators
-assemble_interface!(residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptyInterfaceCache, time) = nothing
+assemble_interface!(residualₑ::AbstractVector, uₑ::AbstractVector, cell, local_face_index::Int, face_caches::EmptyInterfaceCache, time) = nothing
 

--- a/src/modeling/core/element_interface.jl
+++ b/src/modeling/core/element_interface.jl
@@ -1,0 +1,119 @@
+"""
+Supertype for all caches to integrate over volumes.
+
+Interface:
+
+    setup_element_cache(model, qr, ip, ip_geo)
+
+"""
+abstract type AbstractVolumetricElementCache end
+
+"""
+    assemble_element!(Kₑ::AbstractMatrix, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
+Main entry point for bilinear operators
+
+    assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
+Update element matrix in nonlinear operators
+
+    assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
+Update element matrix and residual in nonlinear operators
+
+    assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::AbstractVolumetricElementCache, time)
+Update residual in nonlinear operators
+"""
+assemble_element!
+
+
+"""
+    Utility to execute noop assembly.
+"""
+struct EmptyVolumetricElementCache <: AbstractVolumetricElementCache end
+# Main entry point for bilinear operators
+assemble_element!(Kₑ::AbstractMatrix, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
+# Update element matrix in nonlinear operators
+assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
+# Update element matrix and residual in nonlinear operators
+assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
+# Update residual in nonlinear operators
+assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, element_cache::EmptyVolumetricElementCache, time) = nothing
+
+
+
+"""
+Supertype for all caches to integrate over surfaces.
+
+Interface:
+
+    setup_boundary_cache(model, qr, ip, ip_geo)
+
+"""
+abstract type AbstractSurfaceElementCache end
+
+"""
+    assemble_face!(Kₑ::AbstractMatrix, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+Main entry point for bilinear operators
+
+    assemble_face!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+Update face matrix in nonlinear operators
+
+    assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+Update face matrix and residual in nonlinear operators
+
+    assemble_face!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+Update residual in nonlinear operators
+"""
+assemble_face!
+
+
+"""
+    Utility to execute noop assembly.
+"""
+struct EmptySurfaceCache <: AbstractSurfaceElementCache end
+# Update element matrix in nonlinear operators
+assemble_face!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, local_face_index::Int, face_caches::EmptySurfaceCache, time)    = nothing
+assemble_element!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, local_face_index::Int, face_caches::EmptySurfaceCache, time) = nothing
+# Update element matrix and residual in nonlinear operators
+assemble_face!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time)    = nothing
+assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time) = nothing
+# Update residual in nonlinear operators
+assemble_face!(residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time)    = nothing
+assemble_element!(residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptySurfaceCache, time) = nothing
+@inline is_facet_in_cache(::FacetIndex, cell, ::EmptySurfaceCache) = false
+
+"""
+Supertype for all caches to integrate over interfaces.
+
+Interface:
+
+    setup_interface_cache(model, qr, ip, ip_geo)
+
+"""
+abstract type AbstractInterfaceElementCache end
+
+"""
+    assemble_interface!(Kₑ::AbstractMatrix, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+Main entry point for bilinear operators
+
+    assemble_interface!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+Update face matrix in nonlinear operators
+
+    assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+Update face matrix and residual in nonlinear operators
+
+    assemble_interface!(residualₑ::AbstractVector, u::AbstractVector, cell::CellCache, face_cache::AbstractSurfaceElementCache, time)
+Update residual in nonlinear operators
+"""
+assemble_interface!
+
+
+"""
+Utility to execute noop assembly.
+"""
+struct EmptyInterfaceCache <: AbstractInterfaceElementCache end
+# Update element matrix in nonlinear operators
+assemble_interface!(Kₑ::AbstractMatrix, u::AbstractVector, cell::CellCache, local_face_index::Int, face_caches::EmptyInterfaceCache, time)            = nothing
+# Update element matrix and residual in nonlinear operators
+assemble_interface!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptyInterfaceCache, time) = nothing
+# Update residual in nonlinear operators
+assemble_interface!(residualₑ::AbstractVector, u::AbstractVector, cell, local_face_index::Int, face_caches::EmptyInterfaceCache, time) = nothing
+

--- a/src/modeling/core/mass.jl
+++ b/src/modeling/core/mass.jl
@@ -1,17 +1,16 @@
-# @doc raw"""
-#     BilinearMassIntegrator{MT, CV}
+@doc raw"""
+    BilinearMassIntegrator{MT, CV}
 
-# Assembles the matrix associated to the bilinearform ``a(u,v) = -\int v(x) u(x) dx`` for ``u,v`` from the same function space.
-# """
-"""
-    Represents the integrand of the bilinear form <ϕ,ψ> = ∫ ρϕ ⋅ ψ dΩ .
+Represents the integrand of the bilinearform ``a(u,v) = \int \rho(x) v(x) u(x) dx`` for ``u,v`` from the same function space with some given density field $\rho(x)$.
 """
 struct BilinearMassIntegrator{CoefficientType} <: AbstractBilinearIntegrator
     ρ::CoefficientType
-    # coordinate_system
 end
 
-struct BilinearMassElementCache{IT <: BilinearMassIntegrator, CV}
+"""
+The cache associated with [`BilinearMassIntegrator`](@ref) to assemble element mass matrices.
+"""
+struct BilinearMassElementCache{IT <: BilinearMassIntegrator, CV} <: AbstractVolumetricElementCache
     integrator::IT
     cellvalues::CV
 end

--- a/src/modeling/electrophysiology.jl
+++ b/src/modeling/electrophysiology.jl
@@ -146,48 +146,48 @@ struct AnalyticalTransmembraneStimulationProtocol{F <: AnalyticalCoefficient, T}
     nonzero_intervals::Vector{SVector{2,T}} # helper to speed up rhs
 end
 
-# """
-# The original model formulation (TODO citation) with the structure
+"""
+The original model formulation (TODO citation) with the structure
 
-#  χCₘ∂ₜφₘ = ∇⋅κᵢ∇φᵢ + χ(Iᵢₒₙ(φₘ,𝐬,x) + Iₛₜᵢₘ,ᵢ(x,t))
-#  χCₘ∂ₜφₘ = ∇⋅κₑ∇φₑ - χ(Iᵢₒₙ(φₘ,𝐬,x) + Iₛₜᵢₘ,ₑ(x,t))
-#     ∂ₜ𝐬  = g(φₘ,𝐬,x)
-#  φᵢ - φₑ = φₘ
+ χCₘ∂ₜφₘ = ∇⋅κᵢ∇φᵢ + χ(Iᵢₒₙ(φₘ,𝐬,x) + Iₛₜᵢₘ,ᵢ(x,t))
+ χCₘ∂ₜφₘ = ∇⋅κₑ∇φₑ - χ(Iᵢₒₙ(φₘ,𝐬,x) + Iₛₜᵢₘ,ₑ(x,t))
+    ∂ₜ𝐬  = g(φₘ,𝐬,x)
+ φᵢ - φₑ = φₘ
 
-# !!! note 
-#     Not implemented yet.
-# """
-# struct ParabolicParabolicBidomainModel <: AbstractEPModel
-#     χ
-#     Cₘ
-#     κᵢ
-#     κₑ
-#     stim::AbstractStimulationProtocol
-#     ion::AbstractIonicModel
-# end
+!!! warn 
+    Not implemented yet.
+"""
+struct ParabolicParabolicBidomainModel <: AbstractEPModel
+    χ
+    Cₘ
+    κᵢ
+    κₑ
+    stim::AbstractStimulationProtocol
+    ion::AbstractIonicModel
+end
 
-# """
-# Transformed bidomain model with the structure
+"""
+Transformed bidomain model with the structure
 
-#  χCₘ∂ₜφₘ = ∇⋅κᵢ∇φₘ + ∇⋅κᵢ∇φₑ      + χ(Iᵢₒₙ(φₘ,𝐬,x) + Iₛₜᵢₘ(x,t))
-#       0  = ∇⋅κᵢ∇φₘ + ∇⋅(κᵢ+κₑ)∇φₑ +  Iₛₜᵢₘ,ₑ(t) - Iₛₜᵢₘ,ᵢ(t)
-#     ∂ₜ𝐬  = g(φₘ,𝐬,x)
-#       φᵢ = φₘ + φₑ
+ χCₘ∂ₜφₘ = ∇⋅κᵢ∇φₘ + ∇⋅κᵢ∇φₑ      + χ(Iᵢₒₙ(φₘ,𝐬,x) + Iₛₜᵢₘ(x,t))
+      0  = ∇⋅κᵢ∇φₘ + ∇⋅(κᵢ+κₑ)∇φₑ +  Iₛₜᵢₘ,ₑ(t) - Iₛₜᵢₘ,ᵢ(t)
+    ∂ₜ𝐬  = g(φₘ,𝐬,x)
+      φᵢ = φₘ + φₑ
 
-# This formulation is a transformation of the parabolic-parabolic
-# form (c.f. TODO citation) and has been derived by (TODO citation) first.
+This formulation is a transformation of the parabolic-parabolic
+form (c.f. TODO citation) and has been derived by (TODO citation) first.
 
-# !!! note 
-#     Not implemented yet.
-# """
-# struct ParabolicEllipticBidomainModel <: AbstractEPModel
-#     χ
-#     Cₘ
-#     κᵢ
-#     κₑ
-#     stim::AbstractStimulationProtocol
-#     ion::AbstractIonicModel
-# end
+!!! warn 
+    Not implemented yet.
+"""
+struct ParabolicEllipticBidomainModel <: AbstractEPModel
+    χ
+    Cₘ
+    κᵢ
+    κₑ
+    stim::AbstractStimulationProtocol
+    ion::AbstractIonicModel
+end
 
 """
 Simplification of the bidomain model with the structure

--- a/src/modeling/functions.jl
+++ b/src/modeling/functions.jl
@@ -6,7 +6,7 @@ Supertype for all functions coming from PDE discretizations.
 
 ## Interface
 
-solution_size(::AbstractSemidiscreteFunction)
+    solution_size(::AbstractSemidiscreteFunction)
 """
 abstract type AbstractSemidiscreteFunction <: DiffEqBase.AbstractDiffEqFunction{true} end
 
@@ -19,8 +19,8 @@ Supertype for all functions coming from PDE discretizations with blocked structu
 
 ## Interface
 
-BlockArrays.blocksizes(::AbstractSemidiscreteFunction)
-BlockArrays.blocks(::AbstractSemidiscreteFunction) -> Iterable
+    BlockArrays.blocksizes(::AbstractSemidiscreteFunction)
+    BlockArrays.blocks(::AbstractSemidiscreteFunction) -> Iterable
 """
 abstract type AbstractSemidiscreteBlockedFunction <: AbstractSemidiscreteFunction end
 solution_size(f::AbstractSemidiscreteBlockedFunction) = sum(blocksizes(f))

--- a/src/modeling/solid/elements.jl
+++ b/src/modeling/solid/elements.jl
@@ -16,7 +16,7 @@ end
 
 A generic cache to assemble elements coming from a [StructuralModel](@ref).
 """
-struct StructuralElementCache{M, CMCache, CV}
+struct StructuralElementCache{M, CMCache, CV} <: AbstractVolumetricElementCache
     constitutive_model::M
     internal_model_cache::CMCache
     cv::CV
@@ -24,7 +24,7 @@ end
 
 # TODO how to control dispatch on required input for the material routin?
 # TODO finer granularity on the dispatch here. depending on the evolution law of the internal variable this routine looks slightly different.
-function assemble_element!(Kₑ::Matrix, residualₑ, uₑ, geometry_cache, element_cache::StructuralElementCache, time)
+function assemble_element!(Kₑ::AbstractMatrix, residualₑ::AbstractVector, uₑ::AbstractVector, geometry_cache::CellCache, element_cache::StructuralElementCache, time)
     @unpack constitutive_model, internal_model_cache, cv = element_cache
     ndofs = getnbasefunctions(cv)
 
@@ -49,7 +49,7 @@ function assemble_element!(Kₑ::Matrix, residualₑ, uₑ, geometry_cache, elem
             residualₑ[i] += ∇δui ⊡ P * dΩ
 
             ∇δui∂P∂F = ∇δui ⊡ ∂P∂F # Hoisted computation
-            for j in i:ndofs
+            for j in 1:ndofs
                 ∇δuj = shape_gradient(cv, qp, j)
                 # Add contribution to the tangent
                 Kₑ[i, j] += ( ∇δui∂P∂F ⊡ ∇δuj ) * dΩ
@@ -57,13 +57,13 @@ function assemble_element!(Kₑ::Matrix, residualₑ, uₑ, geometry_cache, elem
         end
 
         # Symmetrize
-        for i in 2:ndofs
-            for j in 1:i
-                ∇δuj = shape_gradient(cv, qp, j)
-                # Add contribution to the tangent
-                Kₑ[i, j] = Kₑ[j, i]
-            end
-        end
+        # for i in 2:ndofs
+        #     for j in 1:i
+        #         ∇δuj = shape_gradient(cv, qp, j)
+        #         # Add contribution to the tangent
+        #         Kₑ[i, j] = Kₑ[j, i]
+        #     end
+        # end
     end
 end
 

--- a/src/solver/nonlinear/nlsolve_common.jl
+++ b/src/solver/nonlinear/nlsolve_common.jl
@@ -7,7 +7,7 @@ eliminate_constraints_from_linearization!(cache::AbstractNonlinearSolverCache, f
 eliminate_constraints_from_increment!(Δu::AbstractVector, f::AbstractSemidiscreteFunction, cache::AbstractNonlinearSolverCache) = apply_zero!(Δu, getch(f))
 function eliminate_constraints_from_increment!(Δu::AbstractVector, f::AbstractSemidiscreteBlockedFunction, cache::AbstractNonlinearSolverCache)
     # TODO be smarter about the block extraction and use info from f
-    Δublocked = PseudoBlockVector(Δu, [blocksizes(f)...])
+    Δublocked = BlockedVector(Δu, [blocksizes(f)...])
     for (i,fi) ∈ enumerate(blocks(f))
         Δublockedi = @view Δublocked[Block(i)]
         eliminate_constraints_from_increment!(Δublockedi, fi, cache)


### PR DESCRIPTION
This PR adds documentation for the element interface and propagate it consistently through the codebase.

## TODOs

* [x] Documentation of assembly
* [x] Define interface
* [x] Compositional element assembly (additive)

# Future PRs

* Subdomains
* RSAFDQ tying -> Surface element and get rid of the tying interface. The tying problem can be solved by adding special elements to the mesh.
* Local buffers instantiated via element caches