### PR TITLE
Separate OS logic in time integrators

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -6,7 +6,7 @@ mutable struct ParaViewWriter{PVD}
     current_file::Union{WriteVTK.DatasetFile, Nothing}
 end
 
-Ferrite.create_vtk_grid(filename::AbstractString, mesh::AbstractGrid) = _thunderbolt_fix_create_vtk_grid(filename, mesh)
+Ferrite.create_vtk_grid(filename::AbstractString, mesh::SimpleMesh) = _thunderbolt_fix_create_vtk_grid(filename, mesh)
 
 function _thunderbolt_fix_create_vtk_grid(filename::AbstractString, grid::AbstractGrid{sdim}) where sdim
     cls = WriteVTK.MeshCell[]

--- a/src/solver/operator_splitting.jl
+++ b/src/solver/operator_splitting.jl
@@ -13,11 +13,11 @@ abstract type AbstractOperatorSplitFunction <: DiffEqBase.AbstractODEFunction{tr
 abstract type AbstractOperatorSplittingAlgorithm end
 abstract type AbstractOperatorSplittingCache end
 
-include("operator_splitting/utils.jl")
 include("operator_splitting/function.jl")
 include("operator_splitting/problem.jl")
 include("operator_splitting/integrator.jl")
 include("operator_splitting/solver.jl")
+include("operator_splitting/utils.jl")
 
 export GenericSplitFunction, OperatorSplittingProblem, LieTrotterGodunov,
     DiffEqBase, init, TimeChoiceIterator,

--- a/src/solver/operator_splitting/function.jl
+++ b/src/solver/operator_splitting/function.jl
@@ -1,6 +1,6 @@
 """
-    GenericSplitFunction(functions::Tuple, dof_ranges::Tuple)
-    GenericSplitFunction(functions::Tuple, dof_ranges::Tuple, syncronizers::Tuple)
+    GenericSplitFunction(functions::Tuple, solution_indices::Tuple)
+    GenericSplitFunction(functions::Tuple, solution_indices::Tuple, syncronizers::Tuple)
 
 This type of function describes a set of connected inner functions in mass-matrix form, as usually found in operator splitting procedures.
 
@@ -11,7 +11,7 @@ struct GenericSplitFunction{fSetType <: Tuple, idxSetType <: Tuple, sSetType <: 
     # The atomic ode functions
     functions::fSetType
     # The ranges for the values in the solution vector.
-    dof_ranges::idxSetType
+    solution_indices::idxSetType
     # Operators to update the ode function parameters
     synchronizers::sSetType
     function GenericSplitFunction(fs::Tuple, drs::Tuple, syncers::Tuple)
@@ -22,8 +22,8 @@ end
 
 function function_size(gsf::GenericSplitFunction)
     alldofs = Set{Int}()
-    for dof_range in gsf.dof_ranges
-        union!(alldofs, dof_range)
+    for solution_indices in gsf.solution_indices
+        union!(alldofs, solution_indices)
     end
     return length(alldofs)
 end
@@ -35,7 +35,7 @@ struct NoExternalSynchronization end
 GenericSplitFunction(fs::Tuple, drs::Tuple) = GenericSplitFunction(fs, drs, ntuple(_->NoExternalSynchronization(), length(fs)))
 
 @inline get_operator(f::GenericSplitFunction, i::Integer) = f.functions[i]
-@inline get_dofrange(f::GenericSplitFunction, i::Integer) = f.dof_ranges[i]
+@inline get_dofrange(f::GenericSplitFunction, i::Integer) = f.solution_indices[i]
 
 recursive_null_parameters(f::AbstractOperatorSplitFunction) = @error "Not implemented"
 recursive_null_parameters(f::GenericSplitFunction) = ntuple(i->recursive_null_parameters(get_operator(f, i)), length(f.functions));

--- a/src/solver/operator_splitting/function.jl
+++ b/src/solver/operator_splitting/function.jl
@@ -39,4 +39,4 @@ GenericSplitFunction(fs::Tuple, drs::Tuple) = GenericSplitFunction(fs, drs, ntup
 
 recursive_null_parameters(f::AbstractOperatorSplitFunction) = @error "Not implemented"
 recursive_null_parameters(f::GenericSplitFunction) = ntuple(i->recursive_null_parameters(get_operator(f, i)), length(f.functions));
-recursive_null_parameters(f::DiffEqBase.AbstractODEFunction) = DiffEqBase.NullParameters()
+recursive_null_parameters(f::DiffEqBase.AbstractDiffEqFunction) = DiffEqBase.NullParameters()

--- a/src/solver/operator_splitting/integrator.jl
+++ b/src/solver/operator_splitting/integrator.jl
@@ -21,8 +21,8 @@ mutable struct OperatorSplittingIntegrator{
     solidxTreeType,
     syncTreeType,
 } <: DiffEqBase.AbstractODEIntegrator{algType, true, uType, tType}
-    f::fType
-    alg::algType
+    const f::fType
+    const alg::algType
     u::uType # Master Solution
     uprev::uType # Master Solution
     tmp::uType # Interpolation buffer
@@ -31,7 +31,7 @@ mutable struct OperatorSplittingIntegrator{
     tprev::tType
     dt::tType # This is the time step length which which we intend to advance
     _dt::tType # This is the time step length which which we use during time marching
-    dtchangeable::Bool # Indicator whether _dt can be changed
+    const dtchangeable::Bool # Indicator whether _dt can be changed
     tstops::heapType
     _tstops::tstopsType # argument to __init used as default argument to reinit!
     saveat::heapType
@@ -62,8 +62,6 @@ function DiffEqBase.__init(
     adaptive = DiffEqBase.isadaptive(alg),
     controller = nothing,
     alias_u0 = true,
-    save_func = (u, t) -> copy(u), # custom kwarg
-    dtchangeable = DiffEqBase.isadaptive(alg),           # custom kwarg
     verbose = true,
     kwargs...,
 )
@@ -74,6 +72,8 @@ function DiffEqBase.__init(
     _dt = dt
     dt = tf > t0 ? dt : -dt
     tType = typeof(dt)
+
+    dtchangeable = DiffEqBase.isadaptive(alg)
 
     if tstops isa AbstractArray || tstops isa Tuple || tstops isa Number
         _tstops = nothing
@@ -90,8 +90,9 @@ function DiffEqBase.__init(
     u     = setup_u(prob, alg, alias_u0)
     uprev = setup_u(prob, alg, false)
     tmp   = setup_u(prob, alg, false)
+    uType                = typeof(u)
 
-    sol = DiffEqBase.build_solution(prob, alg, typeof(t0)[], typeof(save_func(u0, t0))[])
+    sol = DiffEqBase.build_solution(prob, alg, tType[], uType[])
 
     callback = DiffEqBase.CallbackSet(callback)
 

--- a/src/solver/operator_splitting/integrator.jl
+++ b/src/solver/operator_splitting/integrator.jl
@@ -17,7 +17,9 @@ mutable struct OperatorSplittingIntegrator{
     callbackType,
     cacheType,
     solType,
-    subintsetType,
+    subintTreeType,
+    solidxTreeType,
+    syncTreeType,
 } <: DiffEqBase.AbstractODEIntegrator{algType, true, uType, tType}
     f::fType
     alg::algType
@@ -40,7 +42,9 @@ mutable struct OperatorSplittingIntegrator{
     # DiffEqBase.initialize! and DiffEqBase.finalize!
     cache::cacheType
     sol::solType
-    subintegrators::subintsetType
+    subintegrator_tree::subintTreeType
+    solution_index_tree::solidxTreeType
+    synchronizer_tree::syncTreeType
 end
 
 # called by DiffEqBase.init and DiffEqBase.solve
@@ -91,7 +95,8 @@ function DiffEqBase.__init(
 
     callback = DiffEqBase.CallbackSet(callback)
 
-    subintegrators, cache = build_subintegrators_with_cache(
+
+    subintegrator_tree, cache = build_subintegrator_tree_with_cache(
         prob, alg,
         uprev, u,
         1:length(u),
@@ -121,7 +126,9 @@ function DiffEqBase.__init(
         false,
         cache,
         sol,
-        subintegrators,
+        subintegrator_tree,
+        build_solution_index_tree(prob.f),
+        build_synchronizer_tree(prob.f),
     )
     DiffEqBase.initialize!(callback, u0, t0, integrator) # Do I need this?
     return integrator
@@ -131,16 +138,18 @@ DiffEqBase.has_reinit(integrator::OperatorSplittingIntegrator) = true
 function DiffEqBase.reinit!(
     integrator::OperatorSplittingIntegrator,
     u0 = integrator.sol.prob.u0;
-    tspan = integrator.sol.prob.tspan,
+    t0 = integrator.sol.prob.tspan[1],
+    tf = integrator.sol.prob.tspan[2],
     erase_sol = false,
     tstops = integrator._tstops,
     saveat = integrator._saveat,
     reinit_callbacks = true,
     reinit_retcode = true
 )
-    (t0,tf) = tspan
     integrator.u .= u0
+    integrator.uprev .= u0
     integrator.t = t0
+    integrator.tprev = t0
     integrator.tstops, integrator.saveat = tstops_and_saveat_heaps(t0, tf, tstops, saveat)
     if erase_sol
         resize!(integrator.sol.t, 0)
@@ -154,6 +163,32 @@ function DiffEqBase.reinit!(
     end
     if reinit_retcode
         integrator.sol = DiffEqBase.solution_new_retcode(integrator.sol, SciMLBase.ReturnCode.Default)
+    end
+
+    subreinit!(
+        integrator.subintegrator_tree;
+        t0, tf,
+        erase_sol,
+        tstops,
+        saveat,
+        reinit_callbacks,
+        reinit_retcode,
+    )
+end
+
+function subreinit!(
+    subintegrator::DiffEqBase.DEIntegrator;
+    kwargs...
+)
+    DiffEqBase.reinit!(subintegrator, subintegrator.uprev; kwargs...)
+end
+
+function subreinit!(
+    subintegrators::Tuple;
+    kwargs...
+)
+    for subintegrator in subintegrators
+        subreinit!(subintegrator; kwargs...)
     end
 end
 
@@ -171,7 +206,7 @@ function DiffEqBase.solve!(integrator::OperatorSplittingIntegrator)
     end
     DiffEqBase.finalize!(integrator.callback, integrator.u, integrator.t, integrator)
     if DiffEqBase.NAN_CHECK(integrator.u)
-        integrator.sol = DiffEqBase.solution_new_retcode(integrator.sol, SciMLBase.ReturnCode.Failure)
+        integrator.sol = DiffEqBase.solution_new_retcode(integrator.sol, SciMLBase.ReturnCode.Unstable)
     else
         integrator.sol = DiffEqBase.solution_new_retcode(integrator.sol, SciMLBase.ReturnCode.Success)
     end
@@ -191,11 +226,35 @@ function DiffEqBase.step!(integrator::OperatorSplittingIntegrator)
     end
 end
 
-function DiffEqBase.check_error!(integrator::OperatorSplittingIntegrator)
+function SciMLBase.check_error(integrator::OperatorSplittingIntegrator)
+    if !SciMLBase.successful_retcode(integrator.sol) && integrator.sol.retcode != SciMLBase.ReturnCode.Default
+        return integrator.sol.retcode
+    end
+
+    verbose = true # integrator.opts.verbose
+
     if DiffEqBase.NAN_CHECK(integrator._dt) # replace with https://github.com/SciML/OrdinaryDiffEq.jl/blob/373a8eec8024ef1acc6c5f0c87f479aa0cf128c3/lib/OrdinaryDiffEqCore/src/iterator_interface.jl#L5-L6 after moving to sciml integrators
-        integrator.sol = DiffEqBase.solution_new_retcode(integrator.sol, SciMLBase.ReturnCode.Failure)
+        if verbose
+            @warn("NaN dt detected. Likely a NaN value in the state, parameters, or derivative value caused this outcome.")
+        end
+        return SciMLBase.ReturnCode.DtNaN
+    end
+
+    return check_error_subintegrators(integrator, integrator.subintegrator_tree)
+end
+
+function check_error_subintegrators(integrator, subintegrator_tree::Tuple)
+    for subintegrator in subintegrator_tree
+        retcode = check_error_subintegrators(integrator, subintegrator)
+        if !SciMLBase.successful_retcode(retcode) && retcode != SciMLBase.ReturnCode.Default
+            return retcode
+        end
     end
     return integrator.sol.retcode
+end
+
+function check_error_subintegrators(integrator, subintegrator::SciMLBase.DEIntegrator)
+    return SciMLBase.check_error(subintegrator)
 end
 
 function DiffEqBase.step!(integrator::OperatorSplittingIntegrator, dt, stop_at_tdt = false)
@@ -313,8 +372,8 @@ function __step!(integrator)
         !isempty(tstops) && dtchangeable ? tdir(integrator) * min(_dt, abs(first(tstops) - integrator.t)) :
         tdir(integrator) * _dt
 
-    # Propagate information down into the subintegrators
-    synchronize_subintegrators!(integrator)
+    # Propagate information down into the subintegrator_tree
+    synchronize_subintegrator_tree!(integrator)
     tnext = integrator.t + integrator.dt
 
     # Solve inner problems
@@ -366,22 +425,28 @@ end
 # defined as default initialize: https://github.com/SciML/DiffEqBase.jl/blob/master/src/callbacks.jl#L3
 DiffEqBase.u_modified!(i::OperatorSplittingIntegrator, bool) = nothing
 
-function synchronize_subintegrators!(integrator::OperatorSplittingIntegrator)
-    synchronize_subintegrator!(integrator.subintegrators, integrator)
+function synchronize_subintegrator_tree!(integrator::OperatorSplittingIntegrator)
+    synchronize_subintegrator!(integrator.subintegrator_tree, integrator)
 end
 
-@unroll function synchronize_subintegrator!(subintegrators::Tuple, integrator::OperatorSplittingIntegrator)
-    @unroll for subintegrator in subintegrators
+@unroll function synchronize_subintegrator!(subintegrator_tree::Tuple, integrator::OperatorSplittingIntegrator)
+    @unroll for subintegrator in subintegrator_tree
         synchronize_subintegrator!(subintegrator, integrator)
     end
 end
 
+function OS.synchronize_subintegrator!(subintegrator::SciMLBase.DEIntegrator, integrator::OS.OperatorSplittingIntegrator)
+    @unpack t, dt = integrator
+    @assert subintegrator.t == t
+    SciMLBase.set_proposed_dt!(subintegrator, dt)
+end
+
 function advance_solution_to!(integrator::OperatorSplittingIntegrator, cache::AbstractOperatorSplittingCache, tnext::Number)
-    advance_solution_to!(integrator, integrator.subintegrators, integrator.f.dof_ranges, integrator.f.synchronizers, cache, tnext)
+    advance_solution_to!(integrator, integrator.subintegrator_tree, integrator.solution_index_tree, integrator.synchronizer_tree, cache, tnext)
 end
 
 # Dispatch for tree node construction
-function build_subintegrators_with_cache(
+function build_subintegrator_tree_with_cache(
     prob::OperatorSplittingProblem, alg::AbstractOperatorSplittingAlgorithm,
     uprevouter::AbstractVector, uouter::AbstractVector,
     solution_indices,
@@ -390,13 +455,13 @@ function build_subintegrators_with_cache(
     adaptive, verbose,
 )
     (; f, p) = prob
-    subintegrators_with_caches = ntuple(i ->
-        build_subintegrators_with_cache(
+    subintegrator_tree_with_caches = ntuple(i ->
+        build_subintegrator_tree_with_cache(
             get_operator(f, i),
             alg.inner_algs[i],
             p[i],
             uprevouter, uouter,
-            f.dof_ranges[i],
+            f.solution_indices[i],
             t0, dt, tf,
             tstops, saveat, d_discontinuities, callback,
             adaptive, verbose,
@@ -404,17 +469,17 @@ function build_subintegrators_with_cache(
         length(f.functions)
     )
 
-    subintegrators = ntuple(i -> subintegrators_with_caches[i][1], length(f.functions))
-    caches         = ntuple(i -> subintegrators_with_caches[i][2], length(f.functions))
+    subintegrator_tree = ntuple(i -> subintegrator_tree_with_caches[i][1], length(f.functions))
+    caches         = ntuple(i -> subintegrator_tree_with_caches[i][2], length(f.functions))
 
     # TODO fix mixed device type problems we have to be smarter
-    return subintegrators, init_cache(f, alg;
+    return subintegrator_tree, init_cache(f, alg;
         uprev=uprevouter, u=uouter, alias_u=true,
         inner_caches = caches,
     )
 end
 
-function build_subintegrators_with_cache(
+function build_subintegrator_tree_with_cache(
     f::GenericSplitFunction, alg::AbstractOperatorSplittingAlgorithm, p::Tuple,
     uprevouter::AbstractVector, uouter::AbstractVector,
     solution_indices,
@@ -422,13 +487,13 @@ function build_subintegrators_with_cache(
     tstops, saveat, d_discontinuities, callback,
     adaptive, verbose,
 )
-    subintegrators_with_caches = ntuple(i ->
-        build_subintegrators_with_cache(
+    subintegrator_tree_with_caches = ntuple(i ->
+        build_subintegrator_tree_with_cache(
             get_operator(f, i),
             alg.inner_algs[i],
             p[i],
             uprevouter, uouter,
-            f.dof_ranges[i],
+            f.solution_indices[i],
             t0, dt, tf,
             tstops, saveat, d_discontinuities, callback,
             adaptive, verbose,
@@ -436,31 +501,31 @@ function build_subintegrators_with_cache(
         length(f.functions)
     )
 
-    subintegrators = first.(subintegrators_with_caches)
-    inner_caches   = last.(subintegrators_with_caches)
+    subintegrator_tree = first.(subintegrator_tree_with_caches)
+    inner_caches   = last.(subintegrator_tree_with_caches)
 
     # TODO fix mixed device type problems we have to be smarter
     uprev = @view uprevouter[solution_indices]
     u     = @view uouter[solution_indices]
-    return subintegrators, init_cache(f, alg;
+    return subintegrator_tree, init_cache(f, alg;
         uprev = uprev, u = u,
         inner_caches = inner_caches,
     )
 end
 
 # TODO check for type stability
-@unroll function forward_sync_subintegrator!(outer_integrator::OperatorSplittingIntegrator, subintegrators::Tuple, dof_ranges::Tuple, synchronizers::Tuple)
-    i = 0
-    @unroll for subintegrator in subintegrators
-        i += 1
-        forward_sync_subintegrator!(outer_integrator, subintegrator, dof_ranges[i], syncronizers[i])
-    end
+@unroll function forward_sync_subintegrator!(outer_integrator::OperatorSplittingIntegrator, subintegrator_tree::Tuple, solution_indices::Tuple, synchronizers::Tuple)
+    # i = 0
+    # @unroll for subintegrator in subintegrator_tree
+    #     i += 1
+    #     forward_sync_subintegrator!(outer_integrator, subintegrator, solution_indices[i], synchronizers[i])
+    # end
 end
 
-@unroll function backward_sync_subintegrator!(outer_integrator::OperatorSplittingIntegrator, subintegrators::Tuple, dof_range::Tuple)
-    i = 0
-    @unroll for subintegrator in subintegrators
-        i += 1
-        backward_sync_subintegrator!(uparent, subintegrator, synchronizers[i])
-    end
+@unroll function backward_sync_subintegrator!(outer_integrator::OperatorSplittingIntegrator, subintegrator_tree::Tuple, solution_indices::Tuple)
+    # i = 0
+    # @unroll for subintegrator in subintegrator_tree
+    #     i += 1
+    #     backward_sync_subintegrator!(uparent, subintegrator, synchronizers[i])
+    # end
 end

--- a/src/solver/operator_splitting/utils.jl
+++ b/src/solver/operator_splitting/utils.jl
@@ -71,7 +71,7 @@ function forward_sync_external!(outer_integrator::OperatorSplittingIntegrator, i
     synchronize_solution_with_parameters!(outer_integrator, inner_integrator.p, sync)
 end
 
-function synchronize_solution_with_parameters!(outer_integrator::OperatorSplittingIntegrator, p::Any, sync::StandardSynchronizationMap)
+function synchronize_solution_with_parameters!(outer_integrator::OperatorSplittingIntegrator, p::Any, sync)
     error("Outer synchronizer not dispatched for parameter type $(typeof(p)).")
 end
 
@@ -79,7 +79,7 @@ end
 synchronize_solution_with_parameters!(outer_integrator::OperatorSplittingIntegrator, p::DiffEqBase.NullParameters, sync) = nothing
 
 # Default convention is that the first parameter serves as a buffer for the external solution
-# function synchronize_solution_with_parameters!(outer_integrator::OperatorSplittingIntegrator, p::Tuple, sync::StandardSynchronizationMap)
+# function synchronize_solution_with_parameters!(outer_integrator::OperatorSplittingIntegrator, p::Tuple, sync)
 #     @views uouter = outer_integrator.u[sync.parameter_indices]
 #     sync_vectors!(p[1], uouter)
 # end

--- a/src/solver/operator_splitting/utils.jl
+++ b/src/solver/operator_splitting/utils.jl
@@ -22,3 +22,64 @@ function tstops_and_saveat_heaps(t0, tf, tstops, saveat)
 
     return tstops, saveat
 end
+
+
+need_sync(a::AbstractVector, b::AbstractVector) = true
+need_sync(a::SubArray, b::AbstractVector)       = a.parent !== b
+need_sync(a::AbstractVector, b::SubArray)       = a !== b.parent
+need_sync(a::SubArray, b::SubArray)             = a.parent !== b.parent
+
+function sync_vectors!(a, b)
+    if need_sync(a, b) && a !== b
+        a .= b
+    end
+end
+
+
+# struct StandardSynchronizationMap{uMapType, pMapType}
+#     unknown_indices::uMapType
+#     parameter_indices::pMapType
+# end
+
+function forward_sync_subintegrator!(outer_integrator::OperatorSplittingIntegrator, inner_integrator::DiffEqBase.DEIntegrator, dof_range, sync)
+    forward_sync_internal!(outer_integrator, inner_integrator, dof_range)
+    forward_sync_external!(outer_integrator, inner_integrator, sync)
+end
+
+function backward_sync_subintegrator!(outer_integrator::OperatorSplittingIntegrator, inner_integrator::DiffEqBase.DEIntegrator, sync)
+    backward_sync_internal!(outer_integrator, inner_integrator, sync)
+end
+
+# This is a bit tricky, because per default the operator splitting integrators share their solution vector. However, there is also the case
+# when part of the problem is on a different device (thing e.g. about operator A being on CPU and B being on GPU).
+# This case should be handled with special synchronizers.
+forward_sync_internal!(outer_integrator::OperatorSplittingIntegrator, inner_integrator::OperatorSplittingIntegrator, dof_range) = nothing
+backward_sync_internal!(outer_integrator::OperatorSplittingIntegrator, inner_integrator::OperatorSplittingIntegrator, dof_range) = nothing
+
+function forward_sync_internal!(outer_integrator::OperatorSplittingIntegrator, inner_integrator::DiffEqBase.DEIntegrator, unknown_indices)
+    @views uouter = outer_integrator.u[unknown_indices]
+    sync_vectors!(inner_integrator.uprev, uouter)
+end
+function backward_sync_internal!(outer_integrator::OperatorSplittingIntegrator, inner_integrator::DiffEqBase.DEIntegrator, unknown_indices)
+    @views uouter = outer_integrator.u[unknown_indices]
+    sync_vectors!(uouter, inner_integrator.u)
+end
+
+# This is a noop, because operator splitting integrators do not have parameters
+forward_sync_external!(outer_integrator::OperatorSplittingIntegrator, inner_integrator::OperatorSplittingIntegrator, sync::NoExternalSynchronization) = nothing
+function forward_sync_external!(outer_integrator::OperatorSplittingIntegrator, inner_integrator::DiffEqBase.DEIntegrator, sync)
+    synchronize_solution_with_parameters!(outer_integrator, inner_integrator.p, sync)
+end
+
+function synchronize_solution_with_parameters!(outer_integrator::OperatorSplittingIntegrator, p::Any, sync::StandardSynchronizationMap)
+    error("Outer synchronizer not dispatched for parameter type $(typeof(p)).")
+end
+
+# If we encounter NullParameters, then we have the convention for the standard sync map that no external solution is necessary.
+synchronize_solution_with_parameters!(outer_integrator::OperatorSplittingIntegrator, p::DiffEqBase.NullParameters, sync) = nothing
+
+# Default convention is that the first parameter serves as a buffer for the external solution
+# function synchronize_solution_with_parameters!(outer_integrator::OperatorSplittingIntegrator, p::Tuple, sync::StandardSynchronizationMap)
+#     @views uouter = outer_integrator.u[sync.parameter_indices]
+#     sync_vectors!(p[1], uouter)
+# end

--- a/src/solver/operator_splitting/utils.jl
+++ b/src/solver/operator_splitting/utils.jl
@@ -35,12 +35,6 @@ function sync_vectors!(a, b)
     end
 end
 
-
-# struct StandardSynchronizationMap{uMapType, pMapType}
-#     solution_indices::uMapType
-#     parameter_indices::pMapType
-# end
-
 function forward_sync_subintegrator!(outer_integrator::OperatorSplittingIntegrator, inner_integrator::DiffEqBase.DEIntegrator, solution_indices, sync)
     forward_sync_internal!(outer_integrator, inner_integrator, solution_indices)
     forward_sync_external!(outer_integrator, inner_integrator, sync)
@@ -84,7 +78,7 @@ synchronize_solution_with_parameters!(outer_integrator::OperatorSplittingIntegra
 #     sync_vectors!(p[1], uouter)
 # end
 
-
+# TODO this should go into a custom tree data structure instead of into a tuple-tree
 function build_solution_index_tree(f::GenericSplitFunction)
     return ntuple(i->build_solution_index_tree_recursion(f.functions[i], f.solution_indices[i]), length(f.functions))
 end

--- a/src/solver/time/integrator/diffeq-interface.jl
+++ b/src/solver/time/integrator/diffeq-interface.jl
@@ -1,0 +1,359 @@
+# ----------------------------------- SciMLBase.jl Interface ------------------------------------
+SciMLBase.has_stats(::ThunderboltTimeIntegrator) = true
+
+SciMLBase.has_tstop(integrator::ThunderboltTimeIntegrator) = !isempty(integrator.opts.tstops)
+SciMLBase.first_tstop(integrator::ThunderboltTimeIntegrator) = first(integrator.opts.tstops)
+SciMLBase.pop_tstop!(integrator::ThunderboltTimeIntegrator) = pop!(integrator.opts.tstops)
+
+function SciMLBase.add_tstop!(integrator::ThunderboltTimeIntegrator, t)
+    integrator.tdir * (t - integrator.t) < zero(integrator.t) &&
+    error("Tried to add a tstop that is behind the current time. This is strictly forbidden")
+    push!(integrator.opts.tstops, integrator.tdir * t)
+end
+
+@inline function SciMLBase.get_tmp_cache(integrator::ThunderboltTimeIntegrator)
+    return (integrator.cache.tmp,)
+end
+@inline function SciMLBase.get_tmp_cache(integrator::ThunderboltTimeIntegrator, alg::AbstractSolver, cache::AbstractTimeSolverCache)
+    return (cache.tmp,)
+end
+
+function SciMLBase.terminate!(integrator::ThunderboltTimeIntegrator, retcode = ReturnCode.Terminated)
+    integrator.sol = SciMLBase.solution_new_retcode(integrator.sol, retcode)
+    integrator.opts.tstops.valtree = typeof(integrator.opts.tstops.valtree)()
+end
+
+# @inline function SciMLBase.get_du(integrator::ThunderboltTimeIntegrator)
+# end
+
+@inline SciMLBase.get_proposed_dt(integrator::ThunderboltTimeIntegrator) = integrator.dt
+
+@inline function SciMLBase.u_modified!(integrator::ThunderboltTimeIntegrator, bool::Bool)
+    integrator.u_modified = bool
+end
+
+SciMLBase.get_sol(integrator::ThunderboltTimeIntegrator) = integrator.sol
+
+# ---------------------------------- DiffEqBase.jl Interface ------------------------------------
+DiffEqBase.get_tstops(integ::ThunderboltTimeIntegrator) = integ.opts.tstops
+DiffEqBase.get_tstops_array(integ::ThunderboltTimeIntegrator) = get_tstops(integ).valtree
+DiffEqBase.get_tstops_max(integ::ThunderboltTimeIntegrator) = maximum(get_tstops_array(integ))
+
+
+# ----------------------------------- OrdinaryDiffEqCore compat ----------------------------------
+OrdinaryDiffEqCore.has_discontinuity(integrator::ThunderboltTimeIntegrator) = !isempty(integrator.opts.d_discontinuities)
+OrdinaryDiffEqCore.first_discontinuity(integrator::ThunderboltTimeIntegrator) = first(integrator.opts.d_discontinuities)
+OrdinaryDiffEqCore.pop_discontinuity!(integrator::ThunderboltTimeIntegrator) = pop!(integrator.opts.d_discontinuities)
+
+function _postamble!(integrator)
+    DiffEqBase.finalize!(integrator.opts.callback, integrator.u, integrator.t, integrator)
+    OrdinaryDiffEqCore.solution_endpoint_match_cur_integrator!(integrator)
+    fix_solution_buffer_sizes!(integrator, integrator.sol)
+    finalize_integration_monitor(integrator)
+end
+
+OrdinaryDiffEqCore.alg_extrapolates(alg::AbstractSolver) = false
+
+OrdinaryDiffEqCore.choose_algorithm!(integrator, cache::AbstractTimeSolverCache) = nothing
+
+
+# --------------------------- New Interface Stuff (to be upstreamed) ---------------------------------
+
+# Solution looping interface
+function should_accept_step(integrator::ThunderboltTimeIntegrator)
+    if integrator.force_stepfail || integrator.isout
+        return false
+    end
+    return should_accept_step(integrator, integrator.cache, integrator.controller)
+end
+function should_accept_step(integrator::ThunderboltTimeIntegrator, cache, ::Nothing)
+    return !(integrator.force_stepfail)
+end
+
+function accept_step!(integrator::ThunderboltTimeIntegrator)
+    OrdinaryDiffEqCore.increment_accept!(integrator.stats)
+    accept_step!(integrator, integrator.cache, integrator.controller)
+end
+function accept_step!(integrator::ThunderboltTimeIntegrator, cache, controller)
+    store_previous_info!(integrator)
+end
+
+function store_previous_info!(integrator::ThunderboltTimeIntegrator)
+    if length(integrator.uprev) > 0 # Integrator can rollback
+        update_uprev!(integrator)
+    end
+end
+
+function step_header!(integrator::ThunderboltTimeIntegrator)
+    # Accept or reject the step
+    if !is_first_iteration(integrator)
+        if should_accept_step(integrator)
+            accept_step!(integrator)
+        else # Step should be rejected and hence repeated
+            reject_step!(integrator)
+        end
+    elseif integrator.u_modified # && integrator.iter == 0
+        update_uprev!(integrator)
+    end
+
+    # Before stepping we might need to adjust the dt
+    increment_iteration(integrator)
+    OrdinaryDiffEqCore.choose_algorithm!(integrator, integrator.cache)
+    OrdinaryDiffEqCore.fix_dt_at_bounds!(integrator)
+    OrdinaryDiffEqCore.modify_dt_for_tstops!(integrator)
+    integrator.force_stepfail = false
+end
+
+function update_uprev!(integrator::ThunderboltTimeIntegrator)
+    # # OrdinaryDiffEqCore.update_uprev!(integrator) # FIXME recover
+    # if alg_extrapolates(integrator.alg)
+    #     if isinplace(integrator.sol.prob)
+    #         SciMLBase.recursivecopy!(integrator.uprev2, integrator.uprev)
+    #     else
+    #         integrator.uprev2 = integrator.uprev
+    #     end
+    # end
+    # if isinplace(integrator.sol.prob) # This should be dispatched in the integrator directly
+        SciMLBase.recursivecopy!(integrator.uprev, integrator.u)
+        if integrator.alg isa OrdinaryDiffEqCore.DAEAlgorithm
+            SciMLBase.recursivecopy!(integrator.duprev, integrator.du)
+        end
+    # else
+    #     integrator.uprev = integrator.u
+    #     if integrator.alg isa DAEAlgorithm
+    #         integrator.duprev = integrator.du
+    #     end
+    # end
+    nothing
+end
+
+function controller_message_on_dtmin_error(integrator::SciMLBase.DEIntegrator)
+    if isdefined(integrator, :EEst)
+       return ", and step error estimate = $(integrator.EEst)"
+    else
+        return ""
+    end
+end
+
+function SciMLBase.check_error(integrator::ThunderboltTimeIntegrator)
+    if integrator.sol.retcode ∉ (SciMLBase.ReturnCode.Success, SciMLBase.ReturnCode.Default)
+        return integrator.sol.retcode
+    end
+    opts = integrator.opts
+    verbose = opts.verbose
+    # This implementation is intended to be used for ODEIntegrator and
+    # SDEIntegrator.
+    if isnan(integrator.dt)
+        if verbose
+            @warn("NaN dt detected. Likely a NaN value in the state, parameters, or derivative value caused this outcome.")
+        end
+        return SciMLBase.ReturnCode.DtNaN
+    end
+    if hasproperty(integrator, :iter) && hasproperty(opts, :maxiters) && integrator.iter > opts.maxiters
+        if verbose
+            @warn("Interrupted. Larger maxiters is needed. If you are using an integrator for non-stiff ODEs or an automatic switching algorithm (the default), you may want to consider using a method for stiff equations. See the solver pages for more details (e.g. https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/#Stiff-Problems).")
+        end
+        return SciMLBase.ReturnCode.MaxIters
+    end
+
+    # The last part:
+    # Bail out if we take a step with dt less than the minimum value (which may be time dependent)
+    # except if we are successfully taking such a small timestep is to hit a tstop exactly
+    # We also exit if the ODE is unstable according to a user chosen callback
+    # but only if we accepted the step to prevent from bailing out as unstable
+    # when we just took way too big a step)
+    step_accepted = should_accept_step(integrator)
+    step_rejected = !step_accepted
+    force_dtmin   = hasproperty(integrator, :force_dtmin) && integrator.force_dtmin
+    if !force_dtmin && SciMLBase.isadaptive(integrator)
+        dt_below_min      = abs(integrator.dt) ≤ abs(opts.dtmin)
+        before_next_tstop = SciMLBase.has_tstop(integrator) ? integrator.t + integrator.dt < integrator.tdir * SciMLBase.first_tstop(integrator) : true
+        if dt_below_min && (step_rejected || before_next_tstop)
+            if verbose
+                controller_string = controller_message_on_dtmin_error(integrator)
+                @warn("dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t)$(controller_string). Aborting. There is either an error in your model specification or the true solution is unstable.")
+            end
+            return SciMLBase.ReturnCode.DtLessThanMin
+        elseif step_rejected && integrator.t isa AbstractFloat &&
+               abs(integrator.dt) <= abs(eps(integrator.t)) # = DiffEqBase.timedepentdtmin(integrator)
+            if verbose
+                controller_string = controller_message_on_dtmin_error(integrator)
+                @warn("At t=$(integrator.t), dt was forced below floating point epsilon $(integrator.dt)$(controller_string). Aborting. There is either an error in your model specification or the true solution is unstable (or the true solution can not be represented in the precision of $(eltype(integrator.u))).")
+            end
+            return SciMLBase.ReturnCode.Unstable
+        end
+    end
+    if step_accepted && (hasproperty(opts, :unstable_check) && 
+       opts.unstable_check(integrator.dt, integrator.u, integrator.p, integrator.t))
+        if verbose
+            @warn("Instability detected. Aborting")
+        end
+        return SciMLBase.ReturnCode.Unstable
+    end
+    if SciMLBase.last_step_failed(integrator) && !SciMLBase.isadaptive(integrator)
+        if verbose
+            @warn("Newton steps could not converge and algorithm is not adaptive. Use a lower dt.")
+        end
+        return SciMLBase.ReturnCode.ConvergenceFailure
+    end
+    return SciMLBase.ReturnCode.Success
+end
+
+function footer_reset_flags!(integrator)
+    integrator.u_modified = false
+end
+
+function fix_solution_buffer_sizes!(integrator, sol)
+    resize!(integrator.sol.t, integrator.saveiter)
+    resize!(integrator.sol.u, integrator.saveiter)
+    if !(integrator.sol isa SciMLBase.DAESolution)
+        resize!(integrator.sol.k, integrator.saveiter_dense)
+    end
+end
+
+function setup_validity_flags!(integrator, t_next)
+    integrator.isout = integrator.opts.isoutofdomain(integrator.u, integrator.p, t_next)
+end
+
+function step_footer!(integrator::ThunderboltTimeIntegrator)
+    ttmp = integrator.t + integrator.tdir * integrator.dt
+
+    footer_reset_flags!(integrator)
+    setup_validity_flags!(integrator, ttmp)
+
+    if should_accept_step(integrator)
+        integrator.last_step_failed = false
+        integrator.tprev = integrator.t
+        integrator.t = OrdinaryDiffEqCore.fixed_t_for_floatingpoint_error!(integrator, ttmp)
+        OrdinaryDiffEqCore.handle_callbacks!(integrator)
+        adapt_dt!(integrator) # Noop for non-adaptive algorithms
+    elseif integrator.force_stepfail
+        if SciMLBase.isadaptive(integrator)
+            OrdinaryDiffEqCore.post_newton_controller!(integrator, integrator.alg)
+        # elseif integrator.dtchangeable # Non-adaptive but can change dt
+        #     integrator.dt *= integrator.opts.failfactor
+        elseif integrator.last_step_failed
+            return
+        end
+        integrator.last_step_failed = true
+    end
+
+    integration_monitor_step(integrator)
+
+    nothing
+end
+
+notify_integrator_hit_tstop!(integrator) = integrator.just_hit_tstop = true
+
+is_first_iteration(integrator) = integrator.iter == 0
+increment_iteration(integrator) = integrator.iter += 1
+
+function integration_monitor_step(integrator)
+    if integrator.opts.progress && integrator.iter % integrator.opts.progress_steps == 0
+        OrdinaryDiffEqCore.log_step!(integrator.opts.progress_name, integrator.opts.progress_id,
+            integrator.opts.progress_message, integrator.dt, integrator.u,
+            integrator.p, integrator.t, integrator.sol.prob.tspan)
+    end
+end
+
+function finalize_integration_monitor(integrator)
+    if integrator.opts.progress
+        @logmsg(LogLevel(-1),
+            integrator.opts.progress_name,
+            _id=integrator.opts.progress_id,
+            message=integrator.opts.progress_message(integrator.dt, integrator.u,
+                integrator.p, integrator.t),
+            progress="done")
+    end
+end
+
+notify_integrator_hit_tstop!(integrator::ThunderboltTimeIntegrator) = nothing
+
+# TODO upstream into OrdinaryDiffEqCore
+function compute_rate_prototype(prob)
+    u = prob.u0
+
+    tType = eltype(prob.tspan)
+    tTypeNoUnits = typeof(one(tType))
+
+    isdae = (
+        prob.f.mass_matrix != I &&
+        !(prob.f.mass_matrix isa Tuple) &&
+        ArrayInterface.issingular(prob.f.mass_matrix)
+    )
+    if !isdae && isinplace(prob) && u isa AbstractArray && eltype(u) <: Number &&
+        uBottomEltypeNoUnits == uBottomEltype && tType == tTypeNoUnits # Could this be more efficient for other arrays?
+        return SciMLBase.recursivecopy(u)
+    else
+        _compute_rate_prototype_mass_matrix_form(prob)
+    end
+end
+function compute_rate_prototype(prob::SciMLBase.DiscreteProblem)
+    _compute_rate_prototype_mass_matrix_form(prob)
+end
+function _compute_rate_prototype_mass_matrix_form(prob)
+    u = prob.u0
+
+    tType = eltype(prob.tspan)
+    tTypeNoUnits = typeof(one(tType))
+    uBottomEltype        = OrdinaryDiffEqCore.recursive_bottom_eltype(u)
+    uBottomEltypeNoUnits = OrdinaryDiffEqCore.recursive_unitless_bottom_eltype(u)
+    if (uBottomEltypeNoUnits == uBottomEltype && tType == tTypeNoUnits) || eltype(u) <: Enum
+        return u
+    else # has units!
+        return u / oneunit(tType)
+    end
+end
+function compute_rate_prototype(prob::SciMLBase.DAEProblem)
+    return prob.du0
+end
+
+function compute_rate_prototype(prob::AbstractSemidiscreteProblem)
+    _compute_rate_prototype_mass_matrix_form(prob)
+end
+
+# Slightly modified functions are here
+function OrdinaryDiffEqCore.modify_dt_for_tstops!(integrator::ThunderboltTimeIntegrator)
+    if SciMLBase.has_tstop(integrator)
+        tdir_t = integrator.tdir * integrator.t
+        tdir_tstop = SciMLBase.first_tstop(integrator)
+        if integrator.opts.adaptive
+            integrator.dt = integrator.tdir *
+                            min(abs(integrator.dt), abs(tdir_tstop - tdir_t)) # step! to the end
+        elseif integrator.dtchangeable
+            dtpropose = SciMLBase.get_proposed_dt(integrator)
+            if iszero(dtpropose)
+                integrator.dt = integrator.tdir * abs(tdir_tstop - tdir_t)
+            elseif !integrator.force_stepfail
+                # always try to step! with dtcache, but lower if a tstop
+                # however, if force_stepfail then don't set to dtcache, and no tstop worry
+                integrator.dt = integrator.tdir *
+                                min(abs(dtpropose), abs(tdir_tstop - tdir_t)) # step! to the end
+            end
+        end
+    end
+end
+
+function OrdinaryDiffEqCore.handle_tstop!(integrator::ThunderboltTimeIntegrator)
+    if SciMLBase.has_tstop(integrator)
+        tdir_t = integrator.tdir * integrator.t
+        tdir_tstop = SciMLBase.first_tstop(integrator)
+        if tdir_t == tdir_tstop
+            while tdir_t == tdir_tstop #remove all redundant copies
+                res = SciMLBase.pop_tstop!(integrator)
+                SciMLBase.has_tstop(integrator) ? (tdir_tstop = SciMLBase.first_tstop(integrator)) : break
+            end
+            notify_integrator_hit_tstop!(integrator)
+        elseif tdir_t > tdir_tstop
+            if !integrator.dtchangeable
+                SciMLBase.change_t_via_interpolation!(integrator,
+                    integrator.tdir *
+                    SciMLBase.pop_tstop!(integrator), Val{true})
+                    notify_integrator_hit_tstop!(integrator)
+            else
+                error("Something went wrong. Integrator stepped past tstops but the algorithm was dtchangeable. Please report this error.")
+            end
+        end
+    end
+    return nothing
+end

--- a/src/solver/time/integrator/operatorsplitting-interface.jl
+++ b/src/solver/time/integrator/operatorsplitting-interface.jl
@@ -1,11 +1,3 @@
-# TODO some operator splitting methods require to go back in time, so we need to figure out what the best way is.
-OS.tdir(integ::ThunderboltTimeIntegrator) = integ.tdir
-
-function OS.advance_solution_to!(outer_integrator::OS.OperatorSplittingIntegrator, integrator::ThunderboltTimeIntegrator, solution_indices, sync, cache::AbstractTimeSolverCache, tend)
-    dt = tend-integrator.t
-    SciMLBase.step!(integrator, dt, true)
-end
-
 struct DummyODESolution <: SciMLBase.AbstractODESolution{Float64, 2, Vector{Float64}}
     retcode::SciMLBase.ReturnCode.T
 end
@@ -14,8 +6,6 @@ function SciMLBase.solution_new_retcode(sol::DummyODESolution, retcode)
     return DiffEqBase.@set sol.retcode = retcode
 end
 fix_solution_buffer_sizes!(integrator, sol::DummyODESolution) = nothing
-
-OS.recursive_null_parameters(stuff::Union{AbstractSemidiscreteProblem, AbstractSemidiscreteFunction}) = SciMLBase.NullParameters()
 
 function OS.build_subintegrator_tree_with_cache(
     f::DiffEqBase.AbstractDiffEqFunction, # f::AbstractSemidiscreteFunction, # <- This is a temporary hotfix :)

--- a/src/solver/time/integrator/operatorsplitting-interface.jl
+++ b/src/solver/time/integrator/operatorsplitting-interface.jl
@@ -1,7 +1,7 @@
 # TODO some operator splitting methods require to go back in time, so we need to figure out what the best way is.
 OS.tdir(integ::ThunderboltTimeIntegrator) = integ.tdir
 
-function OS.advance_solution_to!(outer_integrator::OS.OperatorSplittingIntegrator, integrator::ThunderboltTimeIntegrator, dof_range, sync, cache::AbstractTimeSolverCache, tend)
+function OS.advance_solution_to!(outer_integrator::OS.OperatorSplittingIntegrator, integrator::ThunderboltTimeIntegrator, solution_indices, sync, cache::AbstractTimeSolverCache, tend)
     dt = tend-integrator.t
     SciMLBase.step!(integrator, dt, true)
 end

--- a/src/solver/time/integrator/operatorsplitting-interface.jl
+++ b/src/solver/time/integrator/operatorsplitting-interface.jl
@@ -1,0 +1,162 @@
+function OS.synchronize_subintegrator!(subintegrator::ThunderboltTimeIntegrator, integrator::OS.OperatorSplittingIntegrator)
+    @unpack t, dt = integrator
+    # subintegrator.t = t
+    # subintegrator.dt = dt
+end
+# TODO some operator splitting methods require to go back in time, so we need to figure out what the best way is.
+OS.tdir(integ::ThunderboltTimeIntegrator) = integ.tdir
+
+function OS.advance_solution_to!(outer_integrator::OS.OperatorSplittingIntegrator, integrator::ThunderboltTimeIntegrator, dof_range, sync, cache::AbstractTimeSolverCache, tend)
+    dt = tend-integrator.t
+    SciMLBase.step!(integrator, dt, true)
+end
+
+struct DummyODESolution <: SciMLBase.AbstractODESolution{Float64, 2, Vector{Float64}}
+    retcode::SciMLBase.ReturnCode.T
+end
+DummyODESolution() = DummyODESolution(SciMLBase.ReturnCode.Default)
+function SciMLBase.solution_new_retcode(sol::DummyODESolution, retcode)
+    return DiffEqBase.@set sol.retcode = retcode
+end
+fix_solution_buffer_sizes!(integrator, sol::DummyODESolution) = nothing
+
+OS.recursive_null_parameters(stuff::Union{AbstractSemidiscreteProblem, AbstractSemidiscreteFunction}) = SciMLBase.NullParameters()
+
+function OS.build_subintegrators_with_cache(
+    f::DiffEqBase.AbstractDiffEqFunction, # f::AbstractSemidiscreteFunction, # <- This is a temporary hotfix :)
+    alg::AbstractSolver, p,
+    uprevouter::AbstractVector, uouter::AbstractVector,
+    solution_indices,
+    t0, dt, tf,
+    tstops, saveat, d_discontinuities, callback,
+    adaptive, verbose,
+    save_end = false,
+    controller = nothing,
+)
+    uprev = @view uprevouter[solution_indices]
+    u     = @view uouter[solution_indices]
+
+    dt > zero(dt) || error("dt must be positive")
+    _dt = dt
+    tdir = tf > t0 ? 1.0 : -1.0
+    tType = typeof(dt)
+
+    if tstops isa AbstractArray || tstops isa Tuple || tstops isa Number
+        _tstops = nothing
+    else
+        _tstops = tstops
+        tstops = ()
+    end
+
+    # Setup tstop logic
+    tstops_internal = OrdinaryDiffEqCore.initialize_tstops(tType, tstops, d_discontinuities, (t0, tf))
+    saveat_internal = OrdinaryDiffEqCore.initialize_saveat(tType, saveat, (t0, tf))
+    d_discontinuities_internal = OrdinaryDiffEqCore.initialize_d_discontinuities(tType, d_discontinuities, (t0, tf))
+
+    cache = setup_solver_cache(f, alg, t0; uprev=uprev, u=u)
+
+    # Setup solution buffers
+    uType                = typeof(u)
+    uBottomEltype        = OrdinaryDiffEqCore.recursive_bottom_eltype(u)
+    uBottomEltypeNoUnits = OrdinaryDiffEqCore.recursive_unitless_bottom_eltype(u)
+
+    # Setup callbacks
+    callbacks_internal = SciMLBase.CallbackSet(callback)
+    max_len_cb = DiffEqBase.max_vector_callback_length_int(callbacks_internal)
+    if max_len_cb !== nothing
+        uBottomEltypeReal = real(uBottomEltype)
+        # if SciMLBase.isinplace(prob)
+        #     callback_cache = SciMLBase.CallbackCache(u, max_len_cb, uBottomEltypeReal,
+        #         uBottomEltypeReal)
+        # else
+            callback_cache = SciMLBase.CallbackCache(max_len_cb, uBottomEltypeReal,
+                uBottomEltypeReal)
+        # end
+    else
+        callback_cache = nothing
+    end
+
+    # # Setup solution
+    # save_idxs, saved_subsystem = SciMLBase.get_save_idxs_and_saved_subsystem(prob, save_idxs)
+
+    # rate_prototype = compute_rate_prototype(prob)
+    # rateType = typeof(rate_prototype)
+    # if save_idxs === nothing
+    #     ksEltype = Vector{rateType}
+    # else
+    #     ks_prototype = rate_prototype[save_idxs]
+    #     ksEltype = Vector{typeof(ks_prototype)}
+    # end
+
+    ts = tType[]
+    ks = uType[]
+
+    # sol = SciMLBase.build_solution(
+    #     prob, alg, ts, uType[],
+    #     # dense = dense, k = ks, saved_subsystem = saved_subsystem,
+    #     calculate_error = false
+    # )
+    sol = DummyODESolution()
+
+    if controller === nothing && adaptive && DiffEqBase.isadaptive(alg)
+        controller = default_controller(alg, cache)
+    end
+
+    save_end = save_end === nothing ? save_everystep || isempty(saveat) || saveat isa Number || tf in saveat : save_end
+
+    # Setup the actual integrator object
+    integrator = ThunderboltTimeIntegrator(
+        alg,
+        f,
+        cache.uₙ,
+        cache.uₙ₋₁,
+        p,
+        t0,
+        t0,
+        dt,
+        tdir,
+        cache,
+        callback_cache,
+        sol,
+        true,
+        adaptive ? controller : nothing,
+        IntegratorStats(),
+        IntegratorOptions(
+            dtmin = zero(tType),
+            dtmax = tType(tf-t0),
+            verbose = verbose,
+            adaptive = adaptive,
+            # maxiters = maxiters,
+            callback = callbacks_internal,
+            save_end = save_end,
+            tstops = tstops_internal,
+            saveat = saveat_internal,
+            d_discontinuities = d_discontinuities_internal,
+            tstops_cache = tstops,
+            saveat_cache = saveat,
+            d_discontinuities_cache = d_discontinuities,
+        ),
+        false,
+        0,
+        false,
+        false,
+        false,
+        false,
+        0,
+        0,
+        false,
+    )
+    OrdinaryDiffEqCore.initialize_callbacks!(integrator)
+    DiffEqBase.initialize!(integrator, integrator.cache)
+
+    if _tstops !== nothing
+        tstops = _tstops(parameter_values(integrator), prob.tspan)
+        for tstop in tstops
+            add_tstop!(integrator, tstop)
+        end
+    end
+
+    OrdinaryDiffEqCore.handle_dt!(integrator)
+
+    return integrator, integrator.cache
+end

--- a/src/solver/time/integrator/operatorsplitting-interface.jl
+++ b/src/solver/time/integrator/operatorsplitting-interface.jl
@@ -1,8 +1,3 @@
-function OS.synchronize_subintegrator!(subintegrator::ThunderboltTimeIntegrator, integrator::OS.OperatorSplittingIntegrator)
-    @unpack t, dt = integrator
-    # subintegrator.t = t
-    # subintegrator.dt = dt
-end
 # TODO some operator splitting methods require to go back in time, so we need to figure out what the best way is.
 OS.tdir(integ::ThunderboltTimeIntegrator) = integ.tdir
 
@@ -22,7 +17,7 @@ fix_solution_buffer_sizes!(integrator, sol::DummyODESolution) = nothing
 
 OS.recursive_null_parameters(stuff::Union{AbstractSemidiscreteProblem, AbstractSemidiscreteFunction}) = SciMLBase.NullParameters()
 
-function OS.build_subintegrators_with_cache(
+function OS.build_subintegrator_tree_with_cache(
     f::DiffEqBase.AbstractDiffEqFunction, # f::AbstractSemidiscreteFunction, # <- This is a temporary hotfix :)
     alg::AbstractSolver, p,
     uprevouter::AbstractVector, uouter::AbstractVector,

--- a/src/solver/time/integrator/type.jl
+++ b/src/solver/time/integrator/type.jl
@@ -91,44 +91,7 @@ mutable struct ThunderboltTimeIntegrator{
     just_hit_tstop::Bool
 end
 
-# ----------------------------------- SciMLBase.jl Interface ------------------------------------
-SciMLBase.has_stats(::ThunderboltTimeIntegrator) = true
-
-SciMLBase.has_tstop(integrator::ThunderboltTimeIntegrator) = !isempty(integrator.opts.tstops)
-SciMLBase.first_tstop(integrator::ThunderboltTimeIntegrator) = first(integrator.opts.tstops)
-SciMLBase.pop_tstop!(integrator::ThunderboltTimeIntegrator) = pop!(integrator.opts.tstops)
-
-function SciMLBase.add_tstop!(integrator::ThunderboltTimeIntegrator, t)
-    integrator.tdir * (t - integrator.t) < zero(integrator.t) &&
-    error("Tried to add a tstop that is behind the current time. This is strictly forbidden")
-    push!(integrator.opts.tstops, integrator.tdir * t)
-end
-
-@inline function SciMLBase.get_tmp_cache(integrator::ThunderboltTimeIntegrator)
-    return (integrator.cache.tmp,)
-end
-@inline function SciMLBase.get_tmp_cache(integrator::ThunderboltTimeIntegrator, alg::AbstractSolver, cache::AbstractTimeSolverCache)
-    return (cache.tmp,)
-end
-
-function SciMLBase.terminate!(integrator::ThunderboltTimeIntegrator, retcode = ReturnCode.Terminated)
-    integrator.sol = SciMLBase.solution_new_retcode(integrator.sol, retcode)
-    integrator.opts.tstops.valtree = typeof(integrator.opts.tstops.valtree)()
-end
-
-# @inline function SciMLBase.get_du(integrator::ThunderboltTimeIntegrator)
-# end
-
-@inline SciMLBase.get_proposed_dt(integrator::ThunderboltTimeIntegrator) = integrator.dt
-
-@inline function SciMLBase.u_modified!(integrator::ThunderboltTimeIntegrator, bool::Bool)
-    integrator.u_modified = bool
-end
-
-SciMLBase.get_sol(integrator::ThunderboltTimeIntegrator) = integrator.sol
-
 # Interpolation
-# TODO via https://github.com/SciML/SciMLBase.jl/blob/master/src/interpolation.jl
 function (integrator::ThunderboltTimeIntegrator)(tmp, t)
     OS.linear_interpolation!(tmp, t, integrator.uprev, integrator.u, integrator.t-integrator.dt, integrator.t)
 end
@@ -151,328 +114,6 @@ function SciMLBase.savevalues!(integrator::ThunderboltTimeIntegrator, force_save
     OrdinaryDiffEqCore._savevalues!(integrator, force_save, reduce_size)
 end
 
-# ----------------------------------- DiffEqBase.jl Interface ------------------------------------
-DiffEqBase.get_tstops(integ::ThunderboltTimeIntegrator) = integ.opts.tstops
-DiffEqBase.get_tstops_array(integ::ThunderboltTimeIntegrator) = get_tstops(integ).valtree
-DiffEqBase.get_tstops_max(integ::ThunderboltTimeIntegrator) = maximum(get_tstops_array(integ))
-
-
-# ----------------------------------- OrdinaryDiffEqCore compat ----------------------------------
-OrdinaryDiffEqCore.has_discontinuity(integrator::ThunderboltTimeIntegrator) = !isempty(integrator.opts.d_discontinuities)
-OrdinaryDiffEqCore.first_discontinuity(integrator::ThunderboltTimeIntegrator) = first(integrator.opts.d_discontinuities)
-OrdinaryDiffEqCore.pop_discontinuity!(integrator::ThunderboltTimeIntegrator) = pop!(integrator.opts.d_discontinuities)
-
-function _postamble!(integrator)
-    DiffEqBase.finalize!(integrator.opts.callback, integrator.u, integrator.t, integrator)
-    OrdinaryDiffEqCore.solution_endpoint_match_cur_integrator!(integrator)
-    fix_solution_buffer_sizes!(integrator, integrator.sol)
-    finalize_integration_monitor(integrator)
-end
-
-OrdinaryDiffEqCore.alg_extrapolates(alg::AbstractSolver) = false
-OrdinaryDiffEqCore.alg_extrapolates(::Nothing) = false # HOTFIX REMOVE THIS
-
-# --------------------------- New Interface Stuff (to be upstreamed) ---------------------------------
-
-# Solution looping interface
-function should_accept_step(integrator::ThunderboltTimeIntegrator)
-    if integrator.force_stepfail || integrator.isout
-        return false
-    end
-    return should_accept_step(integrator, integrator.cache, integrator.controller)
-end
-function should_accept_step(integrator::ThunderboltTimeIntegrator, cache, ::Nothing)
-    return !(integrator.force_stepfail)
-end
-
-function accept_step!(integrator::ThunderboltTimeIntegrator)
-    OrdinaryDiffEqCore.increment_accept!(integrator.stats)
-    accept_step!(integrator, integrator.cache, integrator.controller)
-end
-function accept_step!(integrator::ThunderboltTimeIntegrator, cache, controller)
-    store_previous_info!(integrator)
-end
-
-function store_previous_info!(integrator::ThunderboltTimeIntegrator)
-    if length(integrator.uprev) > 0 # Integrator can rollback
-        update_uprev!(integrator)
-    end
-end
-
-function step_header!(integrator::ThunderboltTimeIntegrator)
-    # Accept or reject the step
-    if !is_first_iteration(integrator)
-        if should_accept_step(integrator)
-            accept_step!(integrator)
-        else # Step should be rejected and hence repeated
-            reject_step!(integrator)
-        end
-    elseif integrator.u_modified # && integrator.iter == 0
-        update_uprev!(integrator)
-    end
-
-    # Before stepping we might need to adjust the dt
-    increment_iteration(integrator)
-    OrdinaryDiffEqCore.choose_algorithm!(integrator, integrator.cache)
-    OrdinaryDiffEqCore.fix_dt_at_bounds!(integrator)
-    OrdinaryDiffEqCore.modify_dt_for_tstops!(integrator)
-    integrator.force_stepfail = false
-end
-
-function update_uprev!(integrator::ThunderboltTimeIntegrator)
-    # # OrdinaryDiffEqCore.update_uprev!(integrator) # FIXME recover
-    # if alg_extrapolates(integrator.alg)
-    #     if isinplace(integrator.sol.prob)
-    #         SciMLBase.recursivecopy!(integrator.uprev2, integrator.uprev)
-    #     else
-    #         integrator.uprev2 = integrator.uprev
-    #     end
-    # end
-    # if isinplace(integrator.sol.prob) # This should be dispatched in the integrator directly
-        SciMLBase.recursivecopy!(integrator.uprev, integrator.u)
-        if integrator.alg isa OrdinaryDiffEqCore.DAEAlgorithm
-            SciMLBase.recursivecopy!(integrator.duprev, integrator.du)
-        end
-    # else
-    #     integrator.uprev = integrator.u
-    #     if integrator.alg isa DAEAlgorithm
-    #         integrator.duprev = integrator.du
-    #     end
-    # end
-    nothing
-end
-
-function controller_message_on_dtmin_error(integrator::SciMLBase.DEIntegrator)
-    if isdefined(integrator, :EEst)
-       return ", and step error estimate = $(integrator.EEst)"
-    else
-        return ""
-    end
-end
-
-function SciMLBase.check_error(integrator::ThunderboltTimeIntegrator)
-    if integrator.sol.retcode ∉ (SciMLBase.ReturnCode.Success, SciMLBase.ReturnCode.Default)
-        return integrator.sol.retcode
-    end
-    opts = integrator.opts
-    verbose = opts.verbose
-    # This implementation is intended to be used for ODEIntegrator and
-    # SDEIntegrator.
-    if isnan(integrator.dt)
-        if verbose
-            @warn("NaN dt detected. Likely a NaN value in the state, parameters, or derivative value caused this outcome.")
-        end
-        return SciMLBase.ReturnCode.DtNaN
-    end
-    if hasproperty(integrator, :iter) && hasproperty(opts, :maxiters) && integrator.iter > opts.maxiters
-        if verbose
-            @warn("Interrupted. Larger maxiters is needed. If you are using an integrator for non-stiff ODEs or an automatic switching algorithm (the default), you may want to consider using a method for stiff equations. See the solver pages for more details (e.g. https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/#Stiff-Problems).")
-        end
-        return SciMLBase.ReturnCode.MaxIters
-    end
-
-    # The last part:
-    # Bail out if we take a step with dt less than the minimum value (which may be time dependent)
-    # except if we are successfully taking such a small timestep is to hit a tstop exactly
-    # We also exit if the ODE is unstable according to a user chosen callback
-    # but only if we accepted the step to prevent from bailing out as unstable
-    # when we just took way too big a step)
-    step_accepted = should_accept_step(integrator)
-    step_rejected = !step_accepted
-    force_dtmin   = hasproperty(integrator, :force_dtmin) && integrator.force_dtmin
-    if !force_dtmin && SciMLBase.isadaptive(integrator)
-        dt_below_min      = abs(integrator.dt) ≤ abs(opts.dtmin)
-        before_next_tstop = SciMLBase.has_tstop(integrator) ? integrator.t + integrator.dt < integrator.tdir * SciMLBase.first_tstop(integrator) : true
-        if dt_below_min && (step_rejected || before_next_tstop)
-            if verbose
-                controller_string = controller_message_on_dtmin_error(integrator)
-                @warn("dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t)$(controller_string). Aborting. There is either an error in your model specification or the true solution is unstable.")
-            end
-            return SciMLBase.ReturnCode.DtLessThanMin
-        elseif step_rejected && integrator.t isa AbstractFloat &&
-               abs(integrator.dt) <= abs(eps(integrator.t)) # = DiffEqBase.timedepentdtmin(integrator)
-            if verbose
-                controller_string = controller_message_on_dtmin_error(integrator)
-                @warn("At t=$(integrator.t), dt was forced below floating point epsilon $(integrator.dt)$(controller_string). Aborting. There is either an error in your model specification or the true solution is unstable (or the true solution can not be represented in the precision of $(eltype(integrator.u))).")
-            end
-            return SciMLBase.ReturnCode.Unstable
-        end
-    end
-    if step_accepted && (hasproperty(opts, :unstable_check) && 
-       opts.unstable_check(integrator.dt, integrator.u, integrator.p, integrator.t))
-        if verbose
-            @warn("Instability detected. Aborting")
-        end
-        return SciMLBase.ReturnCode.Unstable
-    end
-    if SciMLBase.last_step_failed(integrator) && !SciMLBase.isadaptive(integrator)
-        if verbose
-            @warn("Newton steps could not converge and algorithm is not adaptive. Use a lower dt.")
-        end
-        return SciMLBase.ReturnCode.ConvergenceFailure
-    end
-    return SciMLBase.ReturnCode.Success
-end
-
-function footer_reset_flags!(integrator)
-    integrator.u_modified = false
-end
-
-function fix_solution_buffer_sizes!(integrator, sol)
-    resize!(integrator.sol.t, integrator.saveiter)
-    resize!(integrator.sol.u, integrator.saveiter)
-    if !(integrator.sol isa SciMLBase.DAESolution)
-        resize!(integrator.sol.k, integrator.saveiter_dense)
-    end
-end
-
-function setup_validity_flags!(integrator, t_next)
-    integrator.isout = integrator.opts.isoutofdomain(integrator.u, integrator.p, t_next)
-end
-
-function step_footer!(integrator::ThunderboltTimeIntegrator)
-    ttmp = integrator.t + integrator.tdir * integrator.dt
-
-    footer_reset_flags!(integrator)
-    setup_validity_flags!(integrator, ttmp)
-
-    if should_accept_step(integrator)
-        integrator.last_step_failed = false
-        integrator.tprev = integrator.t
-        integrator.t = OrdinaryDiffEqCore.fixed_t_for_floatingpoint_error!(integrator, ttmp)
-        OrdinaryDiffEqCore.handle_callbacks!(integrator)
-        adapt_dt!(integrator) # Noop for non-adaptive algorithms
-    elseif integrator.force_stepfail
-        if SciMLBase.isadaptive(integrator)
-            OrdinaryDiffEqCore.post_newton_controller!(integrator, integrator.alg)
-        # elseif integrator.dtchangeable # Non-adaptive but can change dt
-        #     integrator.dt *= integrator.opts.failfactor
-        elseif integrator.last_step_failed
-            return
-        end
-        integrator.last_step_failed = true
-    end
-
-    integration_monitor_step(integrator)
-
-    nothing
-end
-
-notify_integrator_hit_tstop!(integrator) = integrator.just_hit_tstop = true
-
-is_first_iteration(integrator) = integrator.iter == 0
-increment_iteration(integrator) = integrator.iter += 1
-
-function integration_monitor_step(integrator)
-    if integrator.opts.progress && integrator.iter % integrator.opts.progress_steps == 0
-        OrdinaryDiffEqCore.log_step!(integrator.opts.progress_name, integrator.opts.progress_id,
-            integrator.opts.progress_message, integrator.dt, integrator.u,
-            integrator.p, integrator.t, integrator.sol.prob.tspan)
-    end
-end
-
-function finalize_integration_monitor(integrator)
-    if integrator.opts.progress
-        @logmsg(LogLevel(-1),
-            integrator.opts.progress_name,
-            _id=integrator.opts.progress_id,
-            message=integrator.opts.progress_message(integrator.dt, integrator.u,
-                integrator.p, integrator.t),
-            progress="done")
-    end
-end
-
-notify_integrator_hit_tstop!(integrator::ThunderboltTimeIntegrator) = nothing
-
-# TODO upstream into OrdinaryDiffEqCore
-function compute_rate_prototype(prob)
-    u = prob.u0
-
-    tType = eltype(prob.tspan)
-    tTypeNoUnits = typeof(one(tType))
-
-    isdae = (
-        prob.f.mass_matrix != I &&
-        !(prob.f.mass_matrix isa Tuple) &&
-        ArrayInterface.issingular(prob.f.mass_matrix)
-    )
-    if !isdae && isinplace(prob) && u isa AbstractArray && eltype(u) <: Number &&
-        uBottomEltypeNoUnits == uBottomEltype && tType == tTypeNoUnits # Could this be more efficient for other arrays?
-        return SciMLBase.recursivecopy(u)
-    else
-        _compute_rate_prototype_mass_matrix_form(prob)
-    end
-end
-function compute_rate_prototype(prob::SciMLBase.DiscreteProblem)
-    _compute_rate_prototype_mass_matrix_form(prob)
-end
-function _compute_rate_prototype_mass_matrix_form(prob)
-    u = prob.u0
-
-    tType = eltype(prob.tspan)
-    tTypeNoUnits = typeof(one(tType))
-    uBottomEltype        = OrdinaryDiffEqCore.recursive_bottom_eltype(u)
-    uBottomEltypeNoUnits = OrdinaryDiffEqCore.recursive_unitless_bottom_eltype(u)
-    if (uBottomEltypeNoUnits == uBottomEltype && tType == tTypeNoUnits) || eltype(u) <: Enum
-        return u
-    else # has units!
-        return u / oneunit(tType)
-    end
-end
-function compute_rate_prototype(prob::SciMLBase.DAEProblem)
-    return prob.du0
-end
-
-function compute_rate_prototype(prob::AbstractSemidiscreteProblem)
-    _compute_rate_prototype_mass_matrix_form(prob)
-end
-
-# Slightly modified functions are here
-function OrdinaryDiffEqCore.modify_dt_for_tstops!(integrator::ThunderboltTimeIntegrator)
-    if SciMLBase.has_tstop(integrator)
-        tdir_t = integrator.tdir * integrator.t
-        tdir_tstop = SciMLBase.first_tstop(integrator)
-        if integrator.opts.adaptive
-            integrator.dt = integrator.tdir *
-                            min(abs(integrator.dt), abs(tdir_tstop - tdir_t)) # step! to the end
-        elseif integrator.dtchangeable
-            dtpropose = SciMLBase.get_proposed_dt(integrator)
-            if iszero(dtpropose)
-                integrator.dt = integrator.tdir * abs(tdir_tstop - tdir_t)
-            elseif !integrator.force_stepfail
-                # always try to step! with dtcache, but lower if a tstop
-                # however, if force_stepfail then don't set to dtcache, and no tstop worry
-                integrator.dt = integrator.tdir *
-                                min(abs(dtpropose), abs(tdir_tstop - tdir_t)) # step! to the end
-            end
-        end
-    end
-end
-
-function OrdinaryDiffEqCore.handle_tstop!(integrator::ThunderboltTimeIntegrator)
-    if SciMLBase.has_tstop(integrator)
-        tdir_t = integrator.tdir * integrator.t
-        tdir_tstop = SciMLBase.first_tstop(integrator)
-        if tdir_t == tdir_tstop
-            while tdir_t == tdir_tstop #remove all redundant copies
-                res = SciMLBase.pop_tstop!(integrator)
-                SciMLBase.has_tstop(integrator) ? (tdir_tstop = SciMLBase.first_tstop(integrator)) : break
-            end
-            notify_integrator_hit_tstop!(integrator)
-        elseif tdir_t > tdir_tstop
-            if !integrator.dtchangeable
-                SciMLBase.change_t_via_interpolation!(integrator,
-                    integrator.tdir *
-                    SciMLBase.pop_tstop!(integrator), Val{true})
-                    notify_integrator_hit_tstop!(integrator)
-            else
-                error("Something went wrong. Integrator stepped past tstops but the algorithm was dtchangeable. Please report this error.")
-            end
-        end
-    end
-    return nothing
-end
-
 @inline function SciMLBase.step!(integrator::ThunderboltTimeIntegrator)
     @inbounds while true # Emulate do-while
         step_header!(integrator)
@@ -486,26 +127,6 @@ end
     end
     @inbounds OrdinaryDiffEqCore.handle_tstop!(integrator)
 end
-
-# Controller interface
-function reject_step!(integrator::ThunderboltTimeIntegrator)
-    OrdinaryDiffEqCore.increment_reject!(integrator.stats)
-    reject_step!(integrator, integrator.cache, integrator.controller)
-end
-function reject_step!(integrator::ThunderboltTimeIntegrator, cache, controller)
-    integrator.u .= integrator.uprev
-end
-function reject_step!(integrator::ThunderboltTimeIntegrator, cache, ::Nothing)
-    if length(integrator.uprev) == 0
-        error("Cannot roll back integrator. Aborting time integration step at $(integrator.t).")
-    end
-end
-
-adapt_dt!(integrator::ThunderboltTimeIntegrator) = adapt_dt!(integrator, integrator.cache, integrator.controller)
-function adapt_dt!(integrator::ThunderboltTimeIntegrator, cache, controller)
-    error("Step size control not implemented for $(alg).")
-end
-adapt_dt!(integrator::ThunderboltTimeIntegrator, cache, ::Nothing) = nothing
 
 function SciMLBase.__init(
     prob::AbstractSemidiscreteProblem,
@@ -655,9 +276,6 @@ function SciMLBase.__init(
     )
     OrdinaryDiffEqCore.initialize_callbacks!(integrator)
     DiffEqBase.initialize!(integrator, integrator.cache)
-    # FIXME
-    cache.uₙ .= u
-    cache.uₙ₋₁ .= u
 
     if _tstops !== nothing
         tstops = _tstops(parameter_values(integrator), prob.tspan)
@@ -671,8 +289,15 @@ function SciMLBase.__init(
     return integrator
 end
 
-# TODO what exactly should I do here :)
-DiffEqBase.initialize!(integrator::ThunderboltTimeIntegrator, ::AbstractTimeSolverCache) = nothing
+function DiffEqBase.initialize!(integrator::ThunderboltTimeIntegrator, cache::AbstractTimeSolverCache)
+    if cache.uₙ   !== integrator.u
+        cache.uₙ   .= integrator.u
+    end
+
+    if cache.uₙ₋₁ !== integrator.u
+        cache.uₙ₋₁ .= integrator.u
+    end
+end
 
 function SciMLBase.solve!(integrator::ThunderboltTimeIntegrator)
     @inbounds while SciMLBase.has_tstop(integrator)
@@ -717,188 +342,26 @@ function setup_u(prob::AbstractSemidiscreteProblem, solver, alias_u0)
     end
 end
 
-OrdinaryDiffEqCore.choose_algorithm!(integrator, cache::AbstractTimeSolverCache) = nothing
-
-
-# -------------------------- Operator Splitting Compat ------------------------
-function OS.synchronize_subintegrator!(subintegrator::ThunderboltTimeIntegrator, integrator::OS.OperatorSplittingIntegrator)
-    @unpack t, dt = integrator
-    subintegrator.t = t
-    subintegrator.dt = dt
+# Controller interface
+function reject_step!(integrator::ThunderboltTimeIntegrator)
+    OrdinaryDiffEqCore.increment_reject!(integrator.stats)
+    reject_step!(integrator, integrator.cache, integrator.controller)
 end
-# TODO some operator splitting methods require to go back in time, so we need to figure out what the best way is.
-OS.tdir(integ::ThunderboltTimeIntegrator) = integ.tdir
-
-function OS.advance_solution_to!(outer_integrator::OS.OperatorSplittingIntegrator, integrator::ThunderboltTimeIntegrator, dof_range, sync, cache::AbstractTimeSolverCache, tend)
-    dt = tend-integrator.t
-    SciMLBase.step!(integrator, dt, true)
+function reject_step!(integrator::ThunderboltTimeIntegrator, cache, controller)
+    integrator.u .= integrator.uprev
 end
-
-# @inline function OS.prepare_local_step!(uparent, subintegrator::ThunderboltTimeIntegrator)
-#     # Copy solution into subproblem
-#     uparentview      = @view uparent[subintegrator.indexset]
-#     sync_vectors(subintegrator.u, uparentview)
-#     # Mark previous solution, if necessary
-#     if subintegrator.uprev !== nothing && length(subintegrator.uprev) > 0
-#         sync_vectors(subintegrator.uprev, subintegrator.u)
-#     end
-#     syncronize_parameters!(subintegrator, subintegrator.f, subintegrator.synchronizer)
-# end
-
-# @inline function OS.finalize_local_step!(uparent, subintegrator::ThunderboltTimeIntegrator)
-#     # Copy solution out of subproblem
-#     #
-#     uparentview = @view uparent[subintegrator.indexset]
-#     sync_vectors(uparentview, subintegrator.u)
-# end
-
-struct DummyODESolution <: SciMLBase.AbstractODESolution{Float64, 2, Vector{Float64}}
-    retcode::SciMLBase.ReturnCode.T
-end
-DummyODESolution() = DummyODESolution(SciMLBase.ReturnCode.Default)
-function SciMLBase.solution_new_retcode(sol::DummyODESolution, retcode)
-    return DiffEqBase.@set sol.retcode = retcode
-end
-fix_solution_buffer_sizes!(integrator, sol::DummyODESolution) = nothing
-
-OS.recursive_null_parameters(stuff::Union{AbstractSemidiscreteProblem, AbstractSemidiscreteFunction}) = SciMLBase.NullParameters()
-# syncronize_parameters!(integ, f, ::OS.NoExternalSynchronization) = nothing
-
-function OS.build_subintegrators_with_cache(
-    f::DiffEqBase.AbstractDiffEqFunction, # f::AbstractSemidiscreteFunction, # <- This is a temporary hotfix :)
-    alg::AbstractSolver, p,
-    uprevouter::AbstractVector, uouter::AbstractVector,
-    solution_indices,
-    t0, dt, tf,
-    tstops, saveat, d_discontinuities, callback,
-    adaptive, verbose,
-    save_end = false,
-    controller = nothing,
-)
-    uprev = @view uprevouter[solution_indices]
-    u     = @view uouter[solution_indices]
-
-    dt > zero(dt) || error("dt must be positive")
-    _dt = dt
-    tdir = tf > t0 ? 1.0 : -1.0
-    tType = typeof(dt)
-
-    if tstops isa AbstractArray || tstops isa Tuple || tstops isa Number
-        _tstops = nothing
-    else
-        _tstops = tstops
-        tstops = ()
+function reject_step!(integrator::ThunderboltTimeIntegrator, cache, ::Nothing)
+    if length(integrator.uprev) == 0
+        error("Cannot roll back integrator. Aborting time integration step at $(integrator.t).")
     end
-
-    # Setup tstop logic
-    tstops_internal = OrdinaryDiffEqCore.initialize_tstops(tType, tstops, d_discontinuities, (t0, tf))
-    saveat_internal = OrdinaryDiffEqCore.initialize_saveat(tType, saveat, (t0, tf))
-    d_discontinuities_internal = OrdinaryDiffEqCore.initialize_d_discontinuities(tType, d_discontinuities, (t0, tf))
-
-    cache = setup_solver_cache(f, alg, t0; uprev=uprev, u=u)
-
-    # Setup solution buffers
-    uType                = typeof(u)
-    uBottomEltype        = OrdinaryDiffEqCore.recursive_bottom_eltype(u)
-    uBottomEltypeNoUnits = OrdinaryDiffEqCore.recursive_unitless_bottom_eltype(u)
-
-    # Setup callbacks
-    callbacks_internal = SciMLBase.CallbackSet(callback)
-    max_len_cb = DiffEqBase.max_vector_callback_length_int(callbacks_internal)
-    if max_len_cb !== nothing
-        uBottomEltypeReal = real(uBottomEltype)
-        # if SciMLBase.isinplace(prob)
-        #     callback_cache = SciMLBase.CallbackCache(u, max_len_cb, uBottomEltypeReal,
-        #         uBottomEltypeReal)
-        # else
-            callback_cache = SciMLBase.CallbackCache(max_len_cb, uBottomEltypeReal,
-                uBottomEltypeReal)
-        # end
-    else
-        callback_cache = nothing
-    end
-
-    # # Setup solution
-    # save_idxs, saved_subsystem = SciMLBase.get_save_idxs_and_saved_subsystem(prob, save_idxs)
-
-    # rate_prototype = compute_rate_prototype(prob)
-    # rateType = typeof(rate_prototype)
-    # if save_idxs === nothing
-    #     ksEltype = Vector{rateType}
-    # else
-    #     ks_prototype = rate_prototype[save_idxs]
-    #     ksEltype = Vector{typeof(ks_prototype)}
-    # end
-
-    ts = tType[]
-    ks = uType[]
-
-    # sol = SciMLBase.build_solution(
-    #     prob, alg, ts, uType[],
-    #     # dense = dense, k = ks, saved_subsystem = saved_subsystem,
-    #     calculate_error = false
-    # )
-    sol = DummyODESolution()
-
-    if controller === nothing && adaptive && DiffEqBase.isadaptive(alg)
-        controller = default_controller(alg, cache)
-    end
-
-    save_end = save_end === nothing ? save_everystep || isempty(saveat) || saveat isa Number || tf in saveat : save_end
-
-    # Setup the actual integrator object
-    integrator = ThunderboltTimeIntegrator(
-        alg,
-        f,
-        cache.uₙ,
-        cache.uₙ₋₁,
-        p,
-        t0,
-        t0,
-        dt,
-        tdir,
-        cache,
-        callback_cache,
-        sol,
-        true,
-        adaptive ? controller : nothing,
-        IntegratorStats(),
-        IntegratorOptions(
-            dtmin = zero(tType),
-            dtmax = tType(tf-t0),
-            verbose = verbose,
-            adaptive = adaptive,
-            # maxiters = maxiters,
-            callback = callbacks_internal,
-            save_end = save_end,
-            tstops = tstops_internal,
-            saveat = saveat_internal,
-            d_discontinuities = d_discontinuities_internal,
-            tstops_cache = tstops,
-            saveat_cache = saveat,
-            d_discontinuities_cache = d_discontinuities,
-        ),
-        false,
-        0,
-        false,
-        false,
-        false,
-        false,
-        0,
-        0,
-        false,
-    )
-    OrdinaryDiffEqCore.initialize_callbacks!(integrator)
-    DiffEqBase.initialize!(integrator, integrator.cache)
-
-    if _tstops !== nothing
-        tstops = _tstops(parameter_values(integrator), prob.tspan)
-        for tstop in tstops
-            add_tstop!(integrator, tstop)
-        end
-    end
-
-    OrdinaryDiffEqCore.handle_dt!(integrator)
-
-    return integrator, integrator.cache
 end
+
+adapt_dt!(integrator::ThunderboltTimeIntegrator) = adapt_dt!(integrator, integrator.cache, integrator.controller)
+function adapt_dt!(integrator::ThunderboltTimeIntegrator, cache, controller)
+    error("Step size control not implemented for $(alg).")
+end
+adapt_dt!(integrator::ThunderboltTimeIntegrator, cache, ::Nothing) = nothing
+
+
+include("diffeq-interface.jl")
+include("operatorsplitting-interface.jl")

--- a/src/solver/time/integrator/type.jl
+++ b/src/solver/time/integrator/type.jl
@@ -53,12 +53,10 @@ mutable struct ThunderboltTimeIntegrator{
     fType,
     uType,
     uprevType,
-    indexSetType,
     tType,
     pType,
     cacheType,
     callbackcacheType,
-    syncType,
     solType,
     controllerType,
 }  <: SciMLBase.DEIntegrator{algType, true, uType, tType}
@@ -66,7 +64,6 @@ mutable struct ThunderboltTimeIntegrator{
     const f::fType # Right hand side
     u::uType # Current local solution
     uprev::uprevType
-    indexset::indexSetType
     p::pType
     t::tType
     tprev::tType
@@ -77,7 +74,6 @@ mutable struct ThunderboltTimeIntegrator{
     # We need this one explicitly, because there is no API to access this variable
     # E.g. https://github.com/SciML/DiffEqBase.jl/blob/ceec4c0ae42a5cf50b78ec876ed650993d7a55b5/src/callbacks.jl#L112
     callback_cache::callbackcacheType
-    synchronizer::syncType
     sol::solType
     const dtchangeable::Bool
     controller::controllerType
@@ -537,7 +533,6 @@ function SciMLBase.__init(
                     isempty(saveat),
     dtmin = nothing,
     dtmax = nothing,
-    syncronizer = OS.NoExternalSynchronization(),   # custom kwarg
     kwargs...,
 )
     (; f, u0, p) = prob
@@ -622,7 +617,6 @@ function SciMLBase.__init(
         f,
         cache.uₙ,
         cache.uₙ₋₁,
-        1:length(u0),
         p,
         t0,
         t0,
@@ -630,7 +624,6 @@ function SciMLBase.__init(
         tdir,
         cache,
         callback_cache,
-        syncronizer,
         sol,
         true,
         adaptive ? controller : nothing,
@@ -859,7 +852,6 @@ function OS.build_subintegrators_with_cache(
         f,
         cache.uₙ,
         cache.uₙ₋₁,
-        1:length(u),
         p,
         t0,
         t0,
@@ -867,7 +859,6 @@ function OS.build_subintegrators_with_cache(
         tdir,
         cache,
         callback_cache,
-        OS.NoExternalSynchronization(),
         sol,
         true,
         adaptive ? controller : nothing,

--- a/src/solver/time/integrator/type.jl
+++ b/src/solver/time/integrator/type.jl
@@ -6,7 +6,7 @@ end
 
 IntegratorStats() = IntegratorStats(0,0)
 
-Base.@kwdef  struct IntegratorOptions{tType, msgType, F1, F2, F3, F4, F5, SType, tstopsType, saveatType, discType, tcache, savecache, disccache}
+Base.@kwdef mutable struct IntegratorOptions{tType, msgType, F1, F2, F3, F4, F5, SType, tstopsType, saveatType, discType, tcache, savecache, disccache}
     force_dtmin::Bool = false
     dtmin::tType = eps(tType)
     dtmax::tType = Inf

--- a/src/solver/time/integrator/type.jl
+++ b/src/solver/time/integrator/type.jl
@@ -150,8 +150,7 @@ function SciMLBase.__init(
     controller = nothing,
     maxiters = 1000000,
     dense = save_everystep &&
-                    !(alg isa DAEAlgorithm) && !(prob isa DiscreteProblem) &&
-                    isempty(saveat),
+                    !(alg isa DAEAlgorithm) && !(prob isa DiscreteProblem),
     dtmin = nothing,
     dtmax = nothing,
     kwargs...,
@@ -163,6 +162,8 @@ function SciMLBase.__init(
     _dt = dt
     tdir = tf > t0 ? 1.0 : -1.0
     tType = typeof(dt)
+
+    dtchangeable = DiffEqBase.isadaptive(alg)
 
     dtmin = dtmin === nothing ? tType(0.0) : tType(dtmin)
     dtmax = dtmax === nothing ? tType(tf-t0) : tType(dtmax)
@@ -246,7 +247,7 @@ function SciMLBase.__init(
         cache,
         callback_cache,
         sol,
-        true,
+        dtchangeable,
         adaptive ? controller : nothing,
         IntegratorStats(),
         IntegratorOptions(

--- a/src/solver/time/integrator/type.jl
+++ b/src/solver/time/integrator/type.jl
@@ -331,7 +331,7 @@ function OrdinaryDiffEqCore.perform_step!(integ::ThunderboltTimeIntegrator, cach
 end
 
 function init_cache(prob, alg; dt, kwargs...)
-    return setup_solver_cache(prob.f, alg, prob.tspan[1])
+    return setup_solver_cache(prob.f, alg, prob.tspan[1]; kwargs...)
 end
 
 function setup_u(prob::AbstractSemidiscreteProblem, solver, alias_u0)

--- a/src/solver/time/partitioned_solver.jl
+++ b/src/solver/time/partitioned_solver.jl
@@ -63,12 +63,6 @@ Adapt.@adapt_structure ForwardEulerCellSolverCache
     return true
 end
 
-# function init_cache(prob, alg::ForwardEulerCellSolver; t0)
-#     cache = setup_solver_cache(prob.f, alg, t0)
-#     resize(cache.uₙ₋₁, size(cache.uₙ))
-#     return cache
-# end
-
 function setup_solver_cache(f::PointwiseODEFunction, solver::ForwardEulerCellSolver, t₀; u = nothing, uprev=nothing)
     @unpack npoints, ode = f
     ndofs_local = num_states(ode)
@@ -140,13 +134,6 @@ Adapt.@adapt_structure AdaptiveForwardEulerSubstepperCache
 
     return true
 end
-
-
-# function init_cache(prob, alg::AdaptiveForwardEulerSubstepper; t0)
-#     cache = setup_solver_cache(prob.f, alg, t0)
-#     resize(cache.uₙ₋₁, size(cache.uₙ))
-#     return cache
-# end
 
 function setup_solver_cache(f::PointwiseODEFunction, solver::AdaptiveForwardEulerSubstepper, t₀; u = nothing, uprev=nothing)
     @unpack npoints, ode = f

--- a/src/solver/time_integration.jl
+++ b/src/solver/time_integration.jl
@@ -1,4 +1,4 @@
-include("time/time_integrator.jl")
+include("time/integrator/type.jl")
 include("time/euler.jl")
 include("time/homotopy.jl")
 include("time/partitioned_solver.jl")

--- a/test/integration/test_electrophysiology.jl
+++ b/test/integration/test_electrophysiology.jl
@@ -4,7 +4,7 @@ using Thunderbolt
     function simple_initializer!(u₀, f::GenericSplitFunction)
         # TODO cleaner implementation. We need to extract this from the types or via dispatch.
         heatfun = f.functions[1]
-        heat_dofrange = f.dof_ranges[1]
+        heat_dofrange = f.solution_indices[1]
         odefun = f.functions[2]
         ionic_model = odefun.ode
 

--- a/test/test_integrators.jl
+++ b/test/test_integrators.jl
@@ -2,7 +2,7 @@ import Thunderbolt: OS, ThunderboltTimeIntegrator
 # using BenchmarkTools
 using UnPack
 
-@testset "Operator Splitting API" begin
+# @testset "Operator Splitting API" begin
 
     ODEFunction = Thunderbolt.DiffEqBase.ODEFunction
 
@@ -169,7 +169,7 @@ using UnPack
                 ufinal = copy(integrator.u)
                 @test ufinal ≉ u0 # Make sure the solve did something
 
-                DiffEqBase.reinit!(integrator, u0; tspan)
+                DiffEqBase.reinit!(integrator)
                 @test integrator.sol.retcode == DiffEqBase.ReturnCode.Default
                 for (u, t) in DiffEqBase.TimeChoiceIterator(integrator, 0.0:5.0:100.0)
                 end
@@ -207,7 +207,7 @@ using UnPack
                     integrator_NaN = DiffEqBase.init(prob_NaN, tstepper1, dt=dt, verbose=true, alias_u0=false)
                     @test integrator_NaN.sol.retcode == DiffEqBase.ReturnCode.Default
                     DiffEqBase.solve!(integrator_NaN)
-                    @test integrator_NaN.sol.retcode == DiffEqBase.ReturnCode.Failure
+                    @test integrator_NaN.sol.retcode ∈ (DiffEqBase.ReturnCode.Unstable, DiffEqBase.ReturnCode.DtNaN)
                 end
             end
             integrator = DiffEqBase.init(prob, timestepper, dt=dt, verbose=true, alias_u0=false)
@@ -227,4 +227,4 @@ using UnPack
             end
         end
     end
-end
+# end

--- a/test/test_integrators.jl
+++ b/test/test_integrators.jl
@@ -2,7 +2,7 @@ import Thunderbolt: OS, ThunderboltTimeIntegrator
 # using BenchmarkTools
 using UnPack
 
-# @testset "Operator Splitting API" begin
+@testset "Operator Splitting API" begin
 
     ODEFunction = Thunderbolt.DiffEqBase.ODEFunction
 
@@ -227,4 +227,4 @@ using UnPack
             end
         end
     end
-# end
+end


### PR DESCRIPTION
Currently there is a bit of redundancy in the time integrators and part of the operator splitting logic is contained in the ThunderboltTimeIntegrator. This PR cleanly separates the concerns and removes some redundancies.